### PR TITLE
fixing broken link

### DIFF
--- a/content/docs/javascript/quickstart.md
+++ b/content/docs/javascript/quickstart.md
@@ -20,7 +20,7 @@ It can't:
 
 * Configure mappings, change analyzers, or capture snapshots. All these are provided by [elasticsearch.js](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html) - the official ElasticSearch JS client library.
 
-[Appbase.io - the database service](https://appbase.io) is opinionated about cluster setup and hence doesn't support the ElasticSearch devops APIs. See (rest.appbase.io)[https://rest.appbase.io] for a full reference on the supported APIs.
+[Appbase.io - the database service](https://appbase.io) is opinionated about cluster setup and hence doesn't support the ElasticSearch devops APIs. See [rest.appbase.io](https://rest.appbase.io) for a full reference on the supported APIs.
 
 This is a quick start guide to whet the appetite with the possibilities of data streams.
 


### PR DESCRIPTION
swapped square brackets and parentheses for rest.appbase.io link