### PR TITLE
feat: docs updated for distinct filed prop support

### DIFF
--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -78,7 +78,7 @@ class FlutterSearchBoxApp extends StatelessWidget {
         title: "SearchBox Demo",
         theme: ThemeData(
           primarySwatch: Colors.blue,
-		  visualDensity: VisualDensity.adaptivePlatformDensity,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
         home: HomePage(),
       ),
@@ -94,7 +94,7 @@ class HomePage extends StatelessWidget {
       title: 'SearchBox Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-    	visualDensity: VisualDensity.adaptivePlatformDensity,
+        visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
       home: Scaffold(
         appBar: AppBar(
@@ -131,7 +131,7 @@ class HomePage extends StatelessWidget {
                           },
                           'max_concurrent_group_searches': 4,
                         },
-					));
+                      ));
                 }),
           ],
           title: Text('SearchBox Demo'),
@@ -147,7 +147,8 @@ class HomePage extends StatelessWidget {
               size: 10,
               triggerQueryOnInit: true,
               preserveResults: true,
-			  builder: (context, searchController) => ResultsWidget(searchController)),
+              builder: (context, searchController) =>
+                  ResultsWidget(searchController)),
         ),
       ),
     );
@@ -176,9 +177,10 @@ class ResultsWidget extends StatelessWidget {
           child: ListView.builder(
             itemBuilder: (context, index) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                var offset =
-                    (searchController.from != null ? searchController.from : 0) +
-                        searchController.size;
+                var offset = (searchController.from != null
+                        ? searchController.from
+                        : 0) +
+                    searchController.size;
                 if (index == offset - 1) {
                   if (searchController.results.numberOfResults > offset) {
                     // Load next set of results
@@ -350,9 +352,10 @@ class ResultsWidget extends StatelessWidget {
                               title: Center(
                                 child: RichText(
                                   text: TextSpan(
-                                    text: searchController.results.data.length > 0
-                                        ? "No more results"
-                                        : 'No results found',
+                                    text:
+                                        searchController.results.data.length > 0
+                                            ? "No more results"
+                                            : 'No results found',
                                     style: TextStyle(
                                         color: Colors.black54,
                                         fontSize: 20,
@@ -369,6 +372,7 @@ class ResultsWidget extends StatelessWidget {
     );
   }
 }
+
 ```
 
 ### An example with a facet

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -147,8 +147,7 @@ class HomePage extends StatelessWidget {
               size: 10,
               triggerQueryOnInit: true,
               preserveResults: true,
-              builder: (context, searchController) =>
-                  ResultsWidget(searchController)),
+              builder: (context, searchController) => ResultsWidget(searchController)),
         ),
       ),
     );
@@ -168,8 +167,7 @@ class ResultsWidget extends StatelessWidget {
             child: Container(
               color: Colors.white,
               height: 20,
-              child: Text(
-                  '${searchController.results.numberOfResults} results found in ${searchController.results.time.toString()} ms'),
+              child: Text('${searchController.results.numberOfResults} results found in ${searchController.results.time.toString()} ms'),
             ),
           ),
         ),
@@ -177,10 +175,7 @@ class ResultsWidget extends StatelessWidget {
           child: ListView.builder(
             itemBuilder: (context, index) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                var offset = (searchController.from != null
-                        ? searchController.from
-                        : 0) +
-                    searchController.size;
+                var offset = (searchController.from != null ? searchController.from : 0) + searchController.size;
                 if (index == offset - 1) {
                   if (searchController.results.numberOfResults > offset) {
                     // Load next set of results
@@ -208,8 +203,7 @@ class ResultsWidget extends StatelessWidget {
                                       semanticContainer: true,
                                       clipBehavior: Clip.antiAliasWithSaveLayer,
                                       child: Image.network(
-                                        searchController.results.data[index]
-                                            ["image_medium"],
+                                        searchController.results.data[index]["image_medium"],
                                         fit: BoxFit.fill,
                                       ),
                                       elevation: 5,
@@ -234,8 +228,7 @@ class ResultsWidget extends StatelessWidget {
                                               textStyle: TextStyle(
                                                   fontSize: 15,
                                                   color: Colors.grey,
-                                                  fontWeight:
-                                                      FontWeight.normal),
+                                                  fontWeight: FontWeight.normal),
                                               decoration: BoxDecoration(
                                                 boxShadow: [
                                                   BoxShadow(
@@ -250,15 +243,8 @@ class ResultsWidget extends StatelessWidget {
                                               message:
                                                   'By: ${searchController.results.data[index]["original_title"]}',
                                               child: Text(
-                                                searchController
-                                                            .results
-                                                            .data[index][
-                                                                "original_title"]
-                                                            .length <
-                                                        40
-                                                    ? searchController
-                                                            .results.data[index]
-                                                        ["original_title"]
+                                                searchController.results.data[index]["original_title"].length < 40
+                                                    ? searchController.results.data[index]["original_title"]
                                                     : '${searchController.results.data[index]["original_title"].substring(0, 39)}...',
                                                 style: TextStyle(
                                                   fontSize: 20.0,
@@ -287,12 +273,7 @@ class ResultsWidget extends StatelessWidget {
                                               message:
                                                   'By: ${searchController.results.data[index]["authors"]}',
                                               child: Text(
-                                                searchController
-                                                            .results
-                                                            .data[index]
-                                                                ["authors"]
-                                                            .length >
-                                                        50
+                                                searchController.results.data[index]["authors"].length > 50
                                                     ? 'By: ${searchController.results.data[index]["authors"].substring(0, 49)}...'
                                                     : 'By: ${searchController.results.data[index]["authors"]}',
                                                 style: TextStyle(
@@ -372,7 +353,6 @@ class ResultsWidget extends StatelessWidget {
     );
   }
 }
-
 ```
 
 ### An example with a facet

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -118,9 +118,9 @@ class HomePage extends StatelessWidget {
                           {'field': 'original_title', 'weight': 1},
                           {'field': 'original_title.search', 'weight': 3}
                         ],
-						// This prop is used to return only the distinct value documents for the specified field
-						distinctField: 'authors.keyword',
-						// This prop allows specifying additional options to the distinctField prop
+                        // This prop is used to return only the distinct value documents for the specified field
+                        distinctField: 'authors.keyword',
+                        // This prop allows specifying additional options to the distinctField prop
                         distinctFieldConfig: {
                           'inner_hits': {
                             'name': 'most_recent',
@@ -131,7 +131,7 @@ class HomePage extends StatelessWidget {
                           },
                           'max_concurrent_group_searches': 4,
                         },
-                      ));
+                    ));
                 }),
           ],
           title: Text('SearchBox Demo'),
@@ -147,7 +147,8 @@ class HomePage extends StatelessWidget {
               size: 10,
               triggerQueryOnInit: true,
               preserveResults: true,
-              builder: (context, searchController) => ResultsWidget(searchController)),
+              builder: (context, searchController) =>
+                  ResultsWidget(searchController)),
         ),
       ),
     );
@@ -176,9 +177,10 @@ class ResultsWidget extends StatelessWidget {
           child: ListView.builder(
             itemBuilder: (context, index) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                var offset =
-                    (searchController.from != null ? searchController.from : 0) +
-                        searchController.size;
+                var offset = (searchController.from != null
+                        ? searchController.from
+                        : 0) +
+                    searchController.size;
                 if (index == offset - 1) {
                   if (searchController.results.numberOfResults > offset) {
                     // Load next set of results
@@ -350,9 +352,10 @@ class ResultsWidget extends StatelessWidget {
                               title: Center(
                                 child: RichText(
                                   text: TextSpan(
-                                    text: searchController.results.data.length > 0
-                                        ? "No more results"
-                                        : 'No results found',
+                                    text:
+                                        searchController.results.data.length > 0
+                                            ? "No more results"
+                                            : 'No results found',
                                     style: TextStyle(
                                         color: Colors.black54,
                                         fontSize: 20,
@@ -369,6 +372,7 @@ class ResultsWidget extends StatelessWidget {
     );
   }
 }
+
 ```
 
 ### An example with a facet

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -78,7 +78,7 @@ class FlutterSearchBoxApp extends StatelessWidget {
         title: "SearchBox Demo",
         theme: ThemeData(
           primarySwatch: Colors.blue,
-          visualDensity: VisualDensity.adaptivePlatformDensity,
+		  visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
         home: HomePage(),
       ),
@@ -131,7 +131,7 @@ class HomePage extends StatelessWidget {
                           },
                           'max_concurrent_group_searches': 4,
                         },
-                      ));
+					));
                 }),
           ],
           title: Text('SearchBox Demo'),

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -118,6 +118,19 @@ class HomePage extends StatelessWidget {
                           {'field': 'original_title', 'weight': 1},
                           {'field': 'original_title.search', 'weight': 3}
                         ],
+						// This prop is used to return only the distinct value documents for the specified field
+						distinctField: 'title.keyword',
+						// This prop allows specifying additional options to the distinctField prop
+                        distinctFieldConfig: {
+                          'inner_hits': {
+                            'name': 'most_recent',
+                            'size': 5,
+                            'sort': [
+                              {'timestamp': 'asc'}
+                            ],
+                          },
+                          'max_concurrent_group_searches': 4,
+                        },
                       ));
                 }),
           ],

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -94,7 +94,7 @@ class HomePage extends StatelessWidget {
       title: 'SearchBox Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
+    	visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
       home: Scaffold(
         appBar: AppBar(
@@ -131,7 +131,7 @@ class HomePage extends StatelessWidget {
                           },
                           'max_concurrent_group_searches': 4,
                         },
-                    ));
+                      ));
                 }),
           ],
           title: Text('SearchBox Demo'),
@@ -147,8 +147,7 @@ class HomePage extends StatelessWidget {
               size: 10,
               triggerQueryOnInit: true,
               preserveResults: true,
-              builder: (context, searchController) =>
-                  ResultsWidget(searchController)),
+			  builder: (context, searchController) => ResultsWidget(searchController)),
         ),
       ),
     );
@@ -177,10 +176,9 @@ class ResultsWidget extends StatelessWidget {
           child: ListView.builder(
             itemBuilder: (context, index) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                var offset = (searchController.from != null
-                        ? searchController.from
-                        : 0) +
-                    searchController.size;
+                var offset =
+                    (searchController.from != null ? searchController.from : 0) +
+                        searchController.size;
                 if (index == offset - 1) {
                   if (searchController.results.numberOfResults > offset) {
                     // Load next set of results
@@ -352,10 +350,9 @@ class ResultsWidget extends StatelessWidget {
                               title: Center(
                                 child: RichText(
                                   text: TextSpan(
-                                    text:
-                                        searchController.results.data.length > 0
-                                            ? "No more results"
-                                            : 'No results found',
+                                    text: searchController.results.data.length > 0
+                                        ? "No more results"
+                                        : 'No results found',
                                     style: TextStyle(
                                         color: Colors.black54,
                                         fontSize: 20,
@@ -372,7 +369,6 @@ class ResultsWidget extends StatelessWidget {
     );
   }
 }
-
 ```
 
 ### An example with a facet

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -119,7 +119,7 @@ class HomePage extends StatelessWidget {
                           {'field': 'original_title.search', 'weight': 3}
                         ],
 						// This prop is used to return only the distinct value documents for the specified field
-						distinctField: 'title.keyword',
+						distinctField: 'authors.keyword',
 						// This prop allows specifying additional options to the distinctField prop
                         distinctFieldConfig: {
                           'inner_hits': {

--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -170,7 +170,7 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
+	```html
         <SearchBox
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -170,20 +170,20 @@ Here, we are specifying that the suggestions should update whenever one of the b
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-        <SearchBox
-            ...
-            distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-        />
-    ```
+```jsx
+<SearchBox
+    ...
+    distinctField="authors.keyword"
+    distinctFieldConfig={{
+	inner_hits: {
+		name: 'most_recent',
+		size: 5,
+		sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
+```
 
 ### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -164,11 +164,11 @@ Here, we are specifying that the suggestions should update whenever one of the b
     Defaults to `false`. If set to `true` than it allows you to create a complex search that includes wildcard characters, searches across multiple fields, and more. Read more about it [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).
 
 -   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 
 -   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```jsx
         <SearchBox

--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -170,15 +170,15 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```html
+	```jsx
         <SearchBox
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			distinctFieldConfig={{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}}

--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -172,13 +172,13 @@ Here, we are specifying that the suggestions should update whenever one of the b
 
 ```jsx
 <SearchBox
-    ...
-    distinctField="authors.keyword"
-    distinctFieldConfig={{
-	inner_hits: {
-		name: 'most_recent',
-		size: 5,
-		sort: [{ timestamp: 'asc' }],
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
 		},
 		max_concurrent_group_searches: 4,
 	}}

--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -114,6 +114,7 @@ Here, we are specifying that the suggestions should update whenever one of the b
     It utilizes `composite aggregations` which are newly introduced in ES v6 and offer vast performance benefits over a traditional terms aggregation.
     You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html).
     You can use `aggregationData` using `onAggregationData` callback or `subscriber`.
+	> Note: This prop has been marked as deprecated starting v1.2.0. Please use the `distinctField` prop instead.
 
 ```jsx
 <SearchBox
@@ -162,6 +163,27 @@ Here, we are specifying that the suggestions should update whenever one of the b
 -   **queryString** `boolean` [optional]
     Defaults to `false`. If set to `true` than it allows you to create a complex search that includes wildcard characters, searches across multiple fields, and more. Read more about it [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).
 
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+	```jsx
+        <SearchBox
+            ...
+            distinctField="..."
+			distinctFieldConfig={{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
 
 ### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
@@ -200,6 +200,27 @@ Here, we are specifying that the results should update whenever one of the black
 -   **selectAllLabel**: string
     This property allows you to add a new property in the list with a particular value in such a way that when selected i.e `value` is similar/contains to that label(`selectAllLabel`) then `term` query will make sure that the `field` exists in the `results`.
 
+-   **distinctField** `String` [optional]
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+-   **distinctFieldConfig** `Object` [optional]
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+	```jsx
+        <SearchComponent
+            ...
+            distinctField="authors.keyword"
+			distinctFieldConfig={{
+				inner_hits: {
+					name: 'most_recent',
+					size: 5,
+					sort: [{ timestamp: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
+
 #### To customize the AutoSuggestions
 
 -   **enablePopularSuggestions** `boolean` [optional]

--- a/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
@@ -208,13 +208,13 @@ Here, we are specifying that the results should update whenever one of the black
 
 ```jsx
 <SearchComponent
-    ...
-    distinctField="authors.keyword"
-    distinctFieldConfig={{
-	inner_hits: {
-		name: 'most_recent',
-		size: 5,
-		sort: [{ timestamp: 'asc' }],
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
 		},
 		max_concurrent_group_searches: 4,
 	}}

--- a/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
@@ -206,20 +206,20 @@ Here, we are specifying that the results should update whenever one of the black
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-        <SearchComponent
-            ...
-            distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-        />
-    ```
+```jsx
+<SearchComponent
+    ...
+    distinctField="authors.keyword"
+    distinctFieldConfig={{
+	inner_hits: {
+		name: 'most_recent',
+		size: 5,
+		sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
+```
 
 #### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -172,12 +172,12 @@ Here, we are specifying that the suggestions should update whenever one of the b
     ...
     distinctField="authors.keyword"
     distinctFieldConfig={{
-		inner_hits: {
-			name: 'most_recent',
-			size: 5,
-			sort: [{ timestamp: 'asc' }],
-		},
-		max_concurrent_group_searches: 4,
+	  inner_hits: {
+	    name: 'most_recent',
+	    size: 5,
+	    sort: [{ timestamp: 'asc' }],
+	},
+	max_concurrent_group_searches: 4,
 	}}
 />
 ```

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -178,7 +178,7 @@ Here, we are specifying that the suggestions should update whenever one of the b
 		sort: [{ timestamp: 'asc' }],
 	},
 	max_concurrent_group_searches: 4,
-	}}
+}}
 />
 ```
 

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -162,10 +162,10 @@ Here, we are specifying that the suggestions should update whenever one of the b
     Defaults to `false`. If set to `true` than it allows you to create a complex search that includes wildcard characters, searches across multiple fields, and more. Read more about it [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).
 
 -   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 -   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```jsx
         <SearchBox

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -168,18 +168,18 @@ Here, we are specifying that the suggestions should update whenever one of the b
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-	<SearchBox
-		...
-		distinctField="authors.keyword"
-		distinctFieldConfig={{
-			inner_hits: {
-				name: 'most_recent',
-				size: 5,
-				sort: [{ timestamp: 'asc' }],
-			},
-			max_concurrent_group_searches: 4,
-		}}
-	/>
+<SearchBox
+    ...
+    distinctField="authors.keyword"
+    distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
 ```
 
 ### To customize the AutoSuggestions

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -167,15 +167,15 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```html
+	```jsx
         <SearchBox
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			distinctFieldConfig={{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}}

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -167,20 +167,20 @@ Here, we are specifying that the suggestions should update whenever one of the b
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-		<SearchBox
-			...
-			distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-		/>
-	```
+```jsx
+	<SearchBox
+		...
+		distinctField="authors.keyword"
+		distinctFieldConfig={{
+			inner_hits: {
+				name: 'most_recent',
+				size: 5,
+				sort: [{ timestamp: 'asc' }],
+			},
+			max_concurrent_group_searches: 4,
+		}}
+	/>
+```
 
 ### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -114,6 +114,7 @@ Here, we are specifying that the suggestions should update whenever one of the b
     It utilizes `composite aggregations` which are newly introduced in ES v6 and offer vast performance benefits over a traditional terms aggregation.
     You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html).
     You can use `aggregationData` using `onAggregationData` callback or `subscriber`.
+	> Note: This prop has been marked as deprecated starting v1.2.0. Please use the `distinctField` prop instead.
 
 ```jsx
 <SearchBox
@@ -159,6 +160,27 @@ Here, we are specifying that the suggestions should update whenever one of the b
 
 -   **queryString** `boolean` [optional]
     Defaults to `false`. If set to `true` than it allows you to create a complex search that includes wildcard characters, searches across multiple fields, and more. Read more about it [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).
+
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+	```jsx
+        <SearchBox
+            ...
+            distinctField="..."
+			distinctFieldConfig={{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
 
 ### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -168,18 +168,18 @@ Here, we are specifying that the suggestions should update whenever one of the b
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-    <SearchBox
-        ....
-		distinctField="authors.keyword"
-		distinctFieldConfig={{
-			inner_hits: {
-				name: 'most_recent',
-				size: 5,
-				sort: [{ timestamp: 'asc' }],
-			},
-			max_concurrent_group_searches: 4,
-		}}
-	/>
+<SearchBox
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
 ```
 
 ### To customize the AutoSuggestions

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -172,10 +172,10 @@ Here, we are specifying that the suggestions should update whenever one of the b
     ...
     distinctField="authors.keyword"
     distinctFieldConfig={{
-	  inner_hits: {
-	    name: 'most_recent',
-	    size: 5,
-	    sort: [{ timestamp: 'asc' }],
+	inner_hits: {
+		name: 'most_recent',
+		size: 5,
+		sort: [{ timestamp: 'asc' }],
 	},
 	max_concurrent_group_searches: 4,
 	}}

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -167,7 +167,7 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
+	```html
         <SearchBox
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -168,18 +168,18 @@ Here, we are specifying that the suggestions should update whenever one of the b
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-<SearchBox
-    ...
-    distinctField="authors.keyword"
-    distinctFieldConfig={{
-	inner_hits: {
-		name: 'most_recent',
-		size: 5,
-		sort: [{ timestamp: 'asc' }],
-		},
-		max_concurrent_group_searches: 4,
-	}}
-/>
+    <SearchBox
+        ....
+		distinctField="authors.keyword"
+		distinctFieldConfig={{
+			inner_hits: {
+				name: 'most_recent',
+				size: 5,
+				sort: [{ timestamp: 'asc' }],
+			},
+			max_concurrent_group_searches: 4,
+		}}
+	/>
 ```
 
 ### To customize the AutoSuggestions

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -169,16 +169,16 @@ Here, we are specifying that the suggestions should update whenever one of the b
 
 	```jsx
 		<SearchBox
-			...
-			distinctField="authors.keyword"
-			distinctFieldConfig={{
-			inner_hits: {
-				name: 'most_recent',
-				size: 5,
-				sort: [{ timestamp: 'asc' }],
-			},
-			max_concurrent_group_searches: 4,
-			}}
+		...
+		distinctField="authors.keyword"
+		distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+		}}
 		/>
 	```
 ### To customize the AutoSuggestions

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -176,9 +176,9 @@ Here, we are specifying that the suggestions should update whenever one of the b
 		name: 'most_recent',
 		size: 5,
 		sort: [{ timestamp: 'asc' }],
-	},
-	max_concurrent_group_searches: 4,
-}}
+		},
+		max_concurrent_group_searches: 4,
+	}}
 />
 ```
 

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -168,20 +168,19 @@ Here, we are specifying that the suggestions should update whenever one of the b
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```jsx
-        <SearchBox
-            ...
-            distinctField="authors.keyword"
+		<SearchBox
+			...
+			distinctField="authors.keyword"
 			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
+			inner_hits: {
+				name: 'most_recent',
+				size: 5,
+				sort: [{ timestamp: 'asc' }],
+			},
+			max_concurrent_group_searches: 4,
 			}}
-        />
-    ```
-
+		/>
+	```
 ### To customize the AutoSuggestions
 
 -   **enablePopularSuggestions** `Boolean`

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -169,18 +169,19 @@ Here, we are specifying that the suggestions should update whenever one of the b
 
 	```jsx
 		<SearchBox
-		...
-		distinctField="authors.keyword"
-		distinctFieldConfig={{
-		inner_hits: {
-			name: 'most_recent',
-			size: 5,
-			sort: [{ timestamp: 'asc' }],
-		},
-		max_concurrent_group_searches: 4,
-		}}
+			...
+			distinctField="authors.keyword"
+			distinctFieldConfig={{
+				inner_hits: {
+					name: 'most_recent',
+					size: 5,
+					sort: [{ timestamp: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
 		/>
 	```
+
 ### To customize the AutoSuggestions
 
 -   **enablePopularSuggestions** `Boolean`

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -208,16 +208,16 @@ Here, we are specifying that the results should update whenever one of the black
 
 	```jsx
 		<SearchComponent
-			...
-			distinctField="authors.keyword"
-			distinctFieldConfig={{
-			inner_hits: {
-				name: 'most_recent',
-				size: 5,
-				sort: [{ timestamp: 'asc' }],
-			},
-			max_concurrent_group_searches: 4,
-			}}
+		...
+		distinctField="authors.keyword"
+		distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+		}}
 		/>
 	```
 

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -207,7 +207,7 @@ Here, we are specifying that the results should update whenever one of the black
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-<SearchBox
+<SearchComponent
     ...
     distinctField="authors.keyword"
     distinctFieldConfig={{

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -206,20 +206,20 @@ Here, we are specifying that the results should update whenever one of the black
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-		<SearchComponent
-			...
-			distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-		/>
-	```
+```jsx
+	<SearchComponent
+		...
+		distinctField="authors.keyword"
+		distinctFieldConfig={{
+			inner_hits: {
+				name: 'most_recent',
+				size: 5,
+				sort: [{ timestamp: 'asc' }],
+			},
+			max_concurrent_group_searches: 4,
+		}}
+	/>
+```
 
 #### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -200,6 +200,27 @@ Here, we are specifying that the results should update whenever one of the black
 -   **selectAllLabel**: string
     This property allows you to add a new property in the list with a particular value in such a way that when selected i.e `value` is similar/contains to that label(`selectAllLabel`) then `term` query will make sure that the `field` exists in the `results`.
 
+-   **distinctField** `String` [optional]
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+-   **distinctFieldConfig** `Object` [optional]
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+	```jsx
+        <SearchComponent
+            ...
+            distinctField="authors.keyword"
+			distinctFieldConfig={{
+				inner_hits: {
+					name: 'most_recent',
+					size: 5,
+					sort: [{ timestamp: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
+
 #### To customize the AutoSuggestions
 
 -   **enablePopularSuggestions** `boolean` [optional]

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -208,16 +208,16 @@ Here, we are specifying that the results should update whenever one of the black
 
 	```jsx
 		<SearchComponent
-		...
-		distinctField="authors.keyword"
-		distinctFieldConfig={{
-		inner_hits: {
-			name: 'most_recent',
-			size: 5,
-			sort: [{ timestamp: 'asc' }],
-		},
-		max_concurrent_group_searches: 4,
-		}}
+			...
+			distinctField="authors.keyword"
+			distinctFieldConfig={{
+				inner_hits: {
+					name: 'most_recent',
+					size: 5,
+					sort: [{ timestamp: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
 		/>
 	```
 

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -208,16 +208,16 @@ Here, we are specifying that the results should update whenever one of the black
 
 ```jsx
 <SearchComponent
-    ...
-    distinctField="authors.keyword"
-    distinctFieldConfig={{
-	inner_hits: {
-		name: 'most_recent',
-		size: 5,
-		sort: [{ timestamp: 'asc' }],
-	},
-	max_concurrent_group_searches: 4,
-}}
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
 />
 ```
 

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -207,16 +207,16 @@ Here, we are specifying that the results should update whenever one of the black
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-<SearchComponent
+<SearchBox
     ...
     distinctField="authors.keyword"
     distinctFieldConfig={{
-		inner_hits: {
-			name: 'most_recent',
-			size: 5,
-			sort: [{ timestamp: 'asc' }],
-		},
-		max_concurrent_group_searches: 4,
+	  inner_hits: {
+	    name: 'most_recent',
+	    size: 5,
+	    sort: [{ timestamp: 'asc' }],
+	},
+	max_concurrent_group_searches: 4,
 	}}
 />
 ```

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -207,14 +207,14 @@ Here, we are specifying that the results should update whenever one of the black
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-<SearchBox
+<SearchComponent
     ...
     distinctField="authors.keyword"
     distinctFieldConfig={{
-	  inner_hits: {
-	    name: 'most_recent',
-	    size: 5,
-	    sort: [{ timestamp: 'asc' }],
+	inner_hits: {
+		name: 'most_recent',
+		size: 5,
+		sort: [{ timestamp: 'asc' }],
 	},
 	max_concurrent_group_searches: 4,
 	}}

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -207,18 +207,18 @@ Here, we are specifying that the results should update whenever one of the black
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-	<SearchComponent
-		...
-		distinctField="authors.keyword"
-		distinctFieldConfig={{
-			inner_hits: {
-				name: 'most_recent',
-				size: 5,
-				sort: [{ timestamp: 'asc' }],
-			},
-			max_concurrent_group_searches: 4,
-		}}
-	/>
+<SearchComponent
+    ...
+    distinctField="authors.keyword"
+    distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
 ```
 
 #### To customize the AutoSuggestions

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -207,19 +207,19 @@ Here, we are specifying that the results should update whenever one of the black
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```jsx
-        <SearchComponent
-            ...
-            distinctField="authors.keyword"
+		<SearchComponent
+			...
+			distinctField="authors.keyword"
 			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
+			inner_hits: {
+				name: 'most_recent',
+				size: 5,
+				sort: [{ timestamp: 'asc' }],
+			},
+			max_concurrent_group_searches: 4,
 			}}
-        />
-    ```
+		/>
+	```
 
 #### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -207,7 +207,7 @@ Here, we are specifying that the results should update whenever one of the black
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 ```jsx
-<SearchComponent
+<SearchBox
     ...
     distinctField="authors.keyword"
     distinctFieldConfig={{
@@ -217,7 +217,7 @@ Here, we are specifying that the results should update whenever one of the black
 		sort: [{ timestamp: 'asc' }],
 	},
 	max_concurrent_group_searches: 4,
-	}}
+}}
 />
 ```
 

--- a/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
+++ b/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
@@ -245,11 +245,11 @@ Check demo [here](https://codesandbox.io/s/3ylrrr0r5q).
     enable creating a URL query string parameter based on the selected value of the list. This is useful for sharing URLs with the component state. Defaults to `false`.
 
 -   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 
 -   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```jsx
         <ReactiveComponent
@@ -266,7 +266,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
         />
     ```
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 
 

--- a/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
+++ b/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
@@ -209,6 +209,8 @@ Check demo [here](https://codesandbox.io/s/3ylrrr0r5q).
 
     > It is possible to override this query by providing `defaultQuery` or `customQuery`.
 
+	> Note: This prop has been marked as deprecated starting v3.18.0. Please use the `distinctField` prop instead.
+
 -   **aggregationSize**
     To set the number of buckets to be returned by aggregations.
 
@@ -241,6 +243,31 @@ Check demo [here](https://codesandbox.io/s/3ylrrr0r5q).
 
 -   **URLParams** `Boolean` [optional]
     enable creating a URL query string parameter based on the selected value of the list. This is useful for sharing URLs with the component state. Defaults to `false`.
+
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
+	```jsx
+        <ReactiveComponent
+            ...
+            distinctField="..."
+			distinctFieldConfig={{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
+
 
 ### Examples
 

--- a/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
+++ b/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
@@ -253,7 +253,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 
 > Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
-	```jsx
+	```html
         <ReactiveComponent
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
+++ b/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
@@ -251,22 +251,23 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
-
-	```html
+	```jsx
         <ReactiveComponent
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			distinctFieldConfig={{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}}
         />
     ```
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
 
 
 ### Examples

--- a/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
+++ b/content/docs/reactivesearch/v3/advanced/reactivecomponent.md
@@ -251,20 +251,20 @@ Check demo [here](https://codesandbox.io/s/3ylrrr0r5q).
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-        <ReactiveComponent
-            ...
-            distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-        />
-    ```
+```jsx
+<ReactiveComponent
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
+```
 
 	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 

--- a/content/docs/reactivesearch/v3/result/reactivelist.md
+++ b/content/docs/reactivesearch/v3/result/reactivelist.md
@@ -248,11 +248,11 @@ Example uses:
 > The fundamental difference between `onPageChange` and `onPageClick` is that `onPageClick` is only called on a manual interaction with the pagination buttons, whereas, `onPageChange` would also be invoked if some other side effects caused the results to update which includes updating filters, queries or changing pages. The behaviour of these two may change in the future versions as we come up with a better API.
 
 -   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 
 -   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```jsx
         <ReactiveList
@@ -269,7 +269,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
         />
     ```
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Sub Components
 

--- a/content/docs/reactivesearch/v3/result/reactivelist.md
+++ b/content/docs/reactivesearch/v3/result/reactivelist.md
@@ -254,22 +254,22 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
-
-	```html
+	```jsx
         <ReactiveList
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			distinctFieldConfig={{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}}
         />
     ```
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Sub Components
 

--- a/content/docs/reactivesearch/v3/result/reactivelist.md
+++ b/content/docs/reactivesearch/v3/result/reactivelist.md
@@ -254,20 +254,20 @@ Example uses:
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-        <ReactiveList
-            ...
-            distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-        />
-    ```
+```jsx
+<ReactiveList
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
+```
 
 	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 

--- a/content/docs/reactivesearch/v3/result/reactivelist.md
+++ b/content/docs/reactivesearch/v3/result/reactivelist.md
@@ -256,7 +256,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 
 > Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
-	```jsx
+	```html
         <ReactiveList
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/v3/result/reactivelist.md
+++ b/content/docs/reactivesearch/v3/result/reactivelist.md
@@ -80,6 +80,9 @@ Example uses:
     > If you are using an app with elastic search version less than 6, then defining this prop will result in error and you need to handle it manually using **renderError** prop.
 
     > It is possible to override this query by providing `defaultQuery`.
+
+	> Note: This prop has been marked as deprecated starting v3.18.0. Please use the `distinctField` prop instead.
+
 -   **aggregationSize**
     To set the number of buckets to be returned by aggregations.
 
@@ -243,6 +246,30 @@ Example uses:
 > Note:
 >
 > The fundamental difference between `onPageChange` and `onPageClick` is that `onPageClick` is only called on a manual interaction with the pagination buttons, whereas, `onPageChange` would also be invoked if some other side effects caused the results to update which includes updating filters, queries or changing pages. The behaviour of these two may change in the future versions as we come up with a better API.
+
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
+	```jsx
+        <ReactiveList
+            ...
+            distinctField="..."
+			distinctFieldConfig={{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
 
 ## Sub Components
 

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -502,7 +502,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 
 > Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
-	```jsx
+	```html
         <CategorySearch
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -500,22 +500,23 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
-
-	```html
+	```jsx
         <CategorySearch
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			distinctFieldConfig={{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}}
         />
     ```
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
 
 
 

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -88,6 +88,9 @@ Example uses:
     > If you are using an app with elastic search version less than 6, then defining this prop will result in error and you need to handle it manually using **renderError** prop.
 
     > It is possible to override this query by providing `defaultQuery` or `customQuery`.
+
+	> Note: This prop has been marked as deprecated starting v3.18.0. Please use the `distinctField` prop instead.
+
 -   **aggregationSize**
     To set the number of buckets to be returned by aggregations.
 
@@ -489,6 +492,31 @@ You can use a custom icon in place of the default icon for the popular searches 
             popularSearchesIcon={<PopularIcon />}
         />
     ```
+
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
+	```jsx
+        <CategorySearch
+            ...
+            distinctField="..."
+			distinctFieldConfig={{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
+
 
 
 ## Demo

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -515,7 +515,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
         />
     ```
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 
 

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -500,20 +500,20 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-        <CategorySearch
-            ...
-            distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-        />
-    ```
+```jsx
+<CategorySearch
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
+```
 
 	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -466,20 +466,20 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
-        <DataSearch
-            ...
-            distinctField="authors.keyword"
-			distinctFieldConfig={{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}}
-        />
-    ```
+```jsx
+<DataSearch
+	....
+	distinctField="authors.keyword"
+	distinctFieldConfig={{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}}
+/>
+```
 
 	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -468,7 +468,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 
 > Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
-	```jsx
+	```html
         <DataSearch
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -83,6 +83,9 @@ Example uses:
     > If you are using an app with elastic search version less than 6, than defining this prop will result in error and you need to handle it manually using **renderError** prop.
 
     > It is possible to override this query by providing `defaultQuery` or `customQuery`.
+
+	> Note: This prop has been marked as deprecated starting v3.18.0. Please use the `distinctField` prop instead.
+
 -   **aggregationSize**
     To set the number of buckets to be returned by aggregations.
 
@@ -456,6 +459,29 @@ You can use a custom icon in place of the default icon for the popular searches 
         />
     ```
 
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
+	```jsx
+        <DataSearch
+            ...
+            distinctField="..."
+			distinctFieldConfig={{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}}
+        />
+    ```
 
 ## Demo
 

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -466,22 +466,22 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
-
-	```html
+	```jsx
         <DataSearch
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			distinctFieldConfig={{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}}
         />
     ```
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -481,7 +481,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
         />
     ```
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -172,11 +172,11 @@ Here, we are specifying that the suggestions should update whenever one of the b
 -   **queryString** `boolean` [optional]
     Defaults to `false`. If set to `true` than it allows you to create a complex search that includes wildcard characters, searches across multiple fields, and more. Read more about it [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).
 
- -   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+-   **distinctField** `String` [optional]
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 -   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```html
         <search-box

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -180,16 +180,16 @@ Here, we are specifying that the suggestions should update whenever one of the b
 
 ```html
 <search-box
-    ...
-    distinctField="authors.keyword"
-    :distinctFieldConfig="{
-	inner_hits: {
-		name: 'most_recent',
-		size: 5,
-		sort: [{ timestamp: 'asc' }],
-	},
-	max_concurrent_group_searches: 4,
-}"
+	....
+	distinctField="authors.keyword"
+	:distinctFieldConfig="{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}"
 />
 ```
 

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -181,12 +181,12 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 	```html
         <search-box
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			:distinctFieldConfig="{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}"

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -178,7 +178,7 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```jsx
+	```html
         <search-box
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -178,20 +178,20 @@ Here, we are specifying that the suggestions should update whenever one of the b
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```html
-        <search-box
-            ...
-            distinctField="authors.keyword"
-			:distinctFieldConfig="{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}"
-        />
-    ```
+```html
+<search-box
+    ...
+    distinctField="authors.keyword"
+    :distinctFieldConfig="{
+	inner_hits: {
+		name: 'most_recent',
+		size: 5,
+		sort: [{ timestamp: 'asc' }],
+	},
+	max_concurrent_group_searches: 4,
+}"
+/>
+```
 
 ### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -114,6 +114,7 @@ Here, we are specifying that the suggestions should update whenever one of the b
     It utilizes `composite aggregations` which are newly introduced in ES v6 and offer vast performance benefits over a traditional terms aggregation.
     You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html).
     You can use `aggregationData` using `onAggregationData` callback or `subscriber`.
+	> Note: This prop has been marked as deprecated starting v1.2.0. Please use the `distinctField` prop instead.
 
 ```html
 <template>
@@ -170,6 +171,27 @@ Here, we are specifying that the suggestions should update whenever one of the b
 
 -   **queryString** `boolean` [optional]
     Defaults to `false`. If set to `true` than it allows you to create a complex search that includes wildcard characters, searches across multiple fields, and more. Read more about it [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).
+
+ -   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+	```jsx
+        <search-box
+            ...
+            distinctField="..."
+			:distinctFieldConfig="{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}"
+        />
+    ```
 
 ### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
@@ -219,20 +219,20 @@ export default App {
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```html
-        <search-component
-            ...
-            distinctField="authors.keyword"
-			:distinctFieldConfig="{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}"
-        />
-    ```
+```html
+<search-component
+    ...
+    distinctField="authors.keyword"
+    :distinctFieldConfig="{
+	inner_hits: {
+		name: 'most_recent',
+		size: 5,
+		sort: [{ timestamp: 'asc' }],
+	},
+	max_concurrent_group_searches: 4,
+}"
+/>
+```
 
 #### To customize the AutoSuggestions
 

--- a/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
@@ -213,6 +213,27 @@ export default App {
 -   **selectAllLabel**: string
     This property allows you to add a new property in the list with a particular value in such a way that when selected i.e `value` is similar/contains to that label(`selectAllLabel`) then `term` query will make sure that the `field` exists in the `results`.
 
+-   **distinctField** `String` [optional]
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+-   **distinctFieldConfig** `Object` [optional]
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+	```html
+        <search-component
+            ...
+            distinctField="authors.keyword"
+			:distinctFieldConfig="{
+				inner_hits: {
+					name: 'most_recent',
+					size: 5,
+					sort: [{ timestamp: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}"
+        />
+    ```
+
 #### To customize the AutoSuggestions
 
 -   **enablePopularSuggestions** `boolean` [optional]

--- a/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
@@ -221,16 +221,16 @@ export default App {
 
 ```html
 <search-component
-    ...
-    distinctField="authors.keyword"
-    :distinctFieldConfig="{
-	inner_hits: {
-		name: 'most_recent',
-		size: 5,
-		sort: [{ timestamp: 'asc' }],
-	},
-	max_concurrent_group_searches: 4,
-}"
+	....
+	distinctField="authors.keyword"
+	:distinctFieldConfig="{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}"
 />
 ```
 

--- a/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
+++ b/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
@@ -296,6 +296,9 @@ We can then use the given ReactiveComponent to be watched by all the filters (vi
     > If you are using an app with elastic search version less than 6, then defining this prop will result in error and you need to catch this error using **error** event.
 
     > It is possible to override this query by providing `defaultQuery`.
+
+	> Note: This prop has been marked as deprecated starting v1.14.0. Please use the `distinctField` prop instead.
+
 -   **aggregationSize**
     To set the number of buckets to be returned by aggregations.
 
@@ -317,6 +320,30 @@ We can then use the given ReactiveComponent to be watched by all the filters (vi
 
 -   **URLParams** `Boolean` [optional]
     enable creating a URL query string parameter based on the selected value of the list. This is useful for sharing URLs with the component state. Defaults to `false`.
+
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
+	```jsx
+        <reactive-component
+            ...
+            distinctField="..."
+			:distinctFieldConfig="{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}"
+        />
+    ```
 
 ## Demo
 

--- a/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
+++ b/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
@@ -330,7 +330,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 
 > Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
-	```jsx
+	```html
         <reactive-component
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
+++ b/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
@@ -322,13 +322,11 @@ We can then use the given ReactiveComponent to be watched by all the filters (vi
     enable creating a URL query string parameter based on the selected value of the list. This is useful for sharing URLs with the component state. Defaults to `false`.
 
 -   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 
 -   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
-
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 	```html
         <reactive-component
@@ -344,6 +342,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 			}"
         />
     ```
+	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
+++ b/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
@@ -333,12 +333,12 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 	```html
         <reactive-component
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			:distinctFieldConfig="{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}"

--- a/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
+++ b/content/docs/reactivesearch/vue/advanced/ReactiveComponent.md
@@ -328,20 +328,20 @@ We can then use the given ReactiveComponent to be watched by all the filters (vi
 -   **distinctFieldConfig** `Object` [optional]
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-	```html
-        <reactive-component
-            ...
-            distinctField="authors.keyword"
-			:distinctFieldConfig="{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}"
-        />
-    ```
+```html
+<reactive-component
+	....
+	distinctField="authors.keyword"
+	:distinctFieldConfig="{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}"
+/>
+```
 	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Demo

--- a/content/docs/reactivesearch/vue/result/ReactiveList.md
+++ b/content/docs/reactivesearch/vue/result/ReactiveList.md
@@ -199,13 +199,12 @@ Example uses:
     applies a default query to the result component. This query will be run when no other components are being watched (via React prop), as well as in conjunction with the query generated from the React prop. The function should return a query.
 
 -   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 
 -   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 	```html
         <reactive-list
@@ -221,6 +220,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 			}"
         />
     ```
+	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Sub Components
 

--- a/content/docs/reactivesearch/vue/result/ReactiveList.md
+++ b/content/docs/reactivesearch/vue/result/ReactiveList.md
@@ -206,20 +206,20 @@ Example uses:
 	This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
 
-	```html
-        <reactive-list
-            ...
-            distinctField="authors.keyword"
-			:distinctFieldConfig="{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}"
-        />
-    ```
+```html
+<reactive-list
+	....
+	distinctField="authors.keyword"
+	:distinctFieldConfig="{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}"
+/>
+```
 	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Sub Components

--- a/content/docs/reactivesearch/vue/result/ReactiveList.md
+++ b/content/docs/reactivesearch/vue/result/ReactiveList.md
@@ -79,6 +79,9 @@ Example uses:
     > If you are using an app with elastic search version less than 6, then defining this prop will result in error and you need to handle it manually using **renderError** slot.
 
     > It is possible to override this query by providing `defaultQuery`.
+
+	> Note: This prop has been marked as deprecated starting v1.14.0. Please use the `distinctField` prop instead.
+
 -   **aggregationSize**
     To set the number of buckets to be returned by aggregations.
 
@@ -194,6 +197,30 @@ Example uses:
     show custom message or component when no results found.
 -   **defaultQuery** `Function` [optional]
     applies a default query to the result component. This query will be run when no other components are being watched (via React prop), as well as in conjunction with the query generated from the React prop. The function should return a query.
+
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
+	```jsx
+        <reactive-list
+            ...
+            distinctField="..."
+			:distinctFieldConfig="{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}"
+        />
+    ```
 
 ## Sub Components
 

--- a/content/docs/reactivesearch/vue/result/ReactiveList.md
+++ b/content/docs/reactivesearch/vue/result/ReactiveList.md
@@ -210,12 +210,12 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 	```html
         <reactive-list
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			:distinctFieldConfig="{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}"

--- a/content/docs/reactivesearch/vue/result/ReactiveList.md
+++ b/content/docs/reactivesearch/vue/result/ReactiveList.md
@@ -207,7 +207,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 
 > Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
-	```jsx
+	```html
         <reactive-list
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -110,6 +110,9 @@ Example uses:
     > If you are using an app with elastic search version less than 6, then defining this prop will result in error and you need to handle it manually using **renderError** slot.
 
     > It is possible to override this query by providing `customQuery`.
+
+	> Note: This prop has been marked as deprecated starting v1.14.0. Please use the `distinctField` prop instead.
+
 -   **aggregationSize**
     To set the number of buckets to be returned by aggregations.
 
@@ -482,6 +485,29 @@ You can use a custom icon in place of the default icon for the popular searches 
         </DataSearch>
     ```
 
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
+
+	```jsx
+        <data-search
+            ...
+            distinctField="..."
+			:distinctFieldConfig="{
+				inner_hits: {
+					name: '...',
+					size: 5,
+					sort: [{ ...: 'asc' }],
+				},
+				max_concurrent_group_searches: 4,
+			}"
+        />
+    ```
 
 ## Demo
 

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -497,12 +497,12 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 	```html
         <data-search
             ...
-            distinctField="..."
+            distinctField="authors.keyword"
 			:distinctFieldConfig="{
 				inner_hits: {
-					name: '...',
+					name: 'most_recent',
 					size: 5,
-					sort: [{ ...: 'asc' }],
+					sort: [{ timestamp: 'asc' }],
 				},
 				max_concurrent_group_searches: 4,
 			}"

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -473,17 +473,20 @@ You can use a custom icon in place of the default icon for the recent search ite
 -   **popularSearchesIcon** `slot-scope` [optional]
 You can use a custom icon in place of the default icon for the popular searches that are shown when `enablePopularSuggestions` prop is set to true. You can also provide styles using the `popular-search-icon` key in the `innerClass` prop.
 
-    ```html
-        <DataSearch
-            ...
-            :enablePopularSuggestions="true"
-            :innerClass="{
-                'popular-search-icon': '...'
-            }"
-        >
-            <popular-icon slot="popularSearchesIcon" />
-        </DataSearch>
-    ```
+```html
+<data-search
+	....
+	distinctField="authors.keyword"
+	:distinctFieldConfig="{
+		inner_hits: {
+			name: 'most_recent',
+			size: 5,
+			sort: [{ timestamp: 'asc' }],
+		},
+		max_concurrent_group_searches: 4,
+	}"
+/>
+```
 
 -   **distinctField** `String` [optional]
 This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -494,7 +494,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 
 > Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
-	```jsx
+	```html
         <data-search
             ...
             distinctField="..."

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -492,8 +492,6 @@ This prop returns only the distinct value documents for the specified field. It 
 -   **distinctFieldConfig** `Object` [optional]
 This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
 
-> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
-
 	```html
         <data-search
             ...
@@ -508,6 +506,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 			}"
         />
     ```
+	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -473,6 +473,25 @@ You can use a custom icon in place of the default icon for the recent search ite
 -   **popularSearchesIcon** `slot-scope` [optional]
 You can use a custom icon in place of the default icon for the popular searches that are shown when `enablePopularSuggestions` prop is set to true. You can also provide styles using the `popular-search-icon` key in the `innerClass` prop.
 
+    ```html
+        <DataSearch
+            ...
+            :enablePopularSuggestions="true"
+            :innerClass="{
+                'popular-search-icon': '...'
+            }"
+        >
+            <popular-icon slot="popularSearchesIcon" />
+        </DataSearch>
+    ```
+
+-   **distinctField** `String` [optional]
+This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
+
+-   **distinctFieldConfig** `Object` [optional]
+This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
+
 ```html
 <data-search
 	....
@@ -487,28 +506,6 @@ You can use a custom icon in place of the default icon for the popular searches 
 	}"
 />
 ```
-
--   **distinctField** `String` [optional]
-This prop returns only the distinct value documents for the specified field. It is equivalent to the `DISTINCT` clause in SQL. It internally uses the collapse feature of Elasticsearch. You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
-
-
--   **distinctFieldConfig** `Object` [optional]
-This prop allows specifying additional options to the `distinctField` prop. Using the allowed DSL, one can specify how to return K distinct values (default value of K=1), sort them by a specific order, or return a second level of distinct values. `distinctFieldConfig` object corresponds to the `inner_hits` key's DSL.  You can read more about it over [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html).
-
-	```html
-        <data-search
-            ...
-            distinctField="authors.keyword"
-			:distinctFieldConfig="{
-				inner_hits: {
-					name: 'most_recent',
-					size: 5,
-					sort: [{ timestamp: 'asc' }],
-				},
-				max_concurrent_group_searches: 4,
-			}"
-        />
-    ```
 	> Note: In order to use the `distinctField` and `distinctFieldConfig` props, the `enableAppbase` prop must be set to true in `ReactiveBase`.
 
 ## Demo


### PR DESCRIPTION
Documentation updated for `distinctField` and `distinctFieldConfig` props in the ReactiveSearch and SearchBox Libraries.

Related PRs - 

- ReactiveSearch - https://github.com/appbaseio/reactivesearch/pull/1654
- SearchBox - https://github.com/appbaseio/searchbox/pull/82
- Flutter SearchBox - https://github.com/appbaseio/flutter-searchbox/pull/6