### PR TITLE
fix: Return default/customQuery in examples

### DIFF
--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -485,9 +485,9 @@ For example,
 <SearchBox
     id="search-component"
     dataField={["original_title", "original_title.search"]}
-    defaultQuery={() => {
+    defaultQuery={() => ({
         "timeout": "1s"
-    }}
+    })}
 />
 ```
 

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -604,9 +604,9 @@ You can use a custom icon in place of the default icon for the popular searches 
 <SearchBox
     id="search-component"
     dataField={["original_title", "original_title.search"]}
-    defaultQuery={() => {
+    defaultQuery={() => ({
         "timeout": "1s"
-    }}
+    })}
 />
 ```
 

--- a/content/docs/reactivesearch/v3/advanced/customqueries.md
+++ b/content/docs/reactivesearch/v3/advanced/customqueries.md
@@ -29,13 +29,13 @@ However, there are cases where you would wish to override the associated query w
 `customQuery` is used to change the component's behavior for its subscribers. It gets triggered after an interaction on the component. Every component is shipped with a default behavior i.e. selecting a city on the SingleList component generates a term query. If you wish to change this behavior i.e. maybe perform additional query besides `term` query or do something else altogether, you can use `customQuery` prop.
 
 ```js
-customQuery = {() => {
+customQuery = {() => ({
     query: {
         term: {
                 user : "Kimchy"
             }
         }
-    }
+    })
 }
 ```
 
@@ -115,13 +115,13 @@ Some of the valid use-cases are:
 For example, in a `SingleList` component showing a list of cities, you may only want to render cities belonging to India.
 
 ```js
-defaultQuery = {() => {
+defaultQuery = {() => ({
         query: {
             terms: {
                 country: [ "India" ]
             }
         }
-    }
+    })
 }
 ```
 

--- a/content/docs/reactivesearch/v3/advanced/migration.md
+++ b/content/docs/reactivesearch/v3/advanced/migration.md
@@ -292,13 +292,13 @@ ReactiveSearch now internally validates the user-provided queries and compute th
 For example, in a `SingleList` component showing list of cities you may only want to render cities belonging to India.
 
 ```js
-defaultQuery = {() => {
+defaultQuery = {() => ({
         query: {
             terms: {
                 country: [ "India" ]
             }
         }
-    }
+    })
 }
 ```
 
@@ -307,13 +307,13 @@ defaultQuery = {() => {
 `customQuery` is used to change the component's behavior for its subscribers. It gets triggered after an interaction on the component. Every component is shipped with a default behavior i.e. selecting a city on the SingleList component generates a term query. If you wish to change this behavior i.e. maybe perform additional query besides `term` query or do something else altogether, you can use `customQuery` prop.
 
 ```js
-customQuery = {() => {
+customQuery = {() => ({
     query: {
         term: {
                 user : "Kimchy"
             }
         }
-    }
+    })
 }
 ```
 


### PR DESCRIPTION
Per https://github.com/appbaseio/reactivesearch/issues/1594, using the documentation examples for some pages about `defaultQuery` and `customQuery` does not work as expected because the the query object is not being returned. This PR updates any instances where an arrow function was used without wrapping the object in parentheses.