### PR TITLE
enable-strict-selection prop usage added for single list components

### DIFF
--- a/content/docs/reactivesearch/v3/list/singledatalist.md
+++ b/content/docs/reactivesearch/v3/list/singledatalist.md
@@ -191,6 +191,8 @@ Or you can also use render function as children
     is a callback function which accepts component's current **value** as a parameter. It is called when you are using the `value` props and the component's value changes. This prop is used to implement the [controlled component](https://reactjs.org/docs/forms/#controlled-components) behavior.
 -   **onError** `Function` [optional]
     gets triggered in case of an error and provides the `error` object, which can be used for debugging or giving feedback to the user if needed.
+-   **enableStrictSelection** `Boolean` [optional]
+    When set to `true`, a selected option can't be unselected. Although, it is possible to change the selected option. Defaults to `false`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/v3/list/singlelist.md
+++ b/content/docs/reactivesearch/v3/list/singlelist.md
@@ -249,6 +249,8 @@ Or you can also use render function as children
     is a callback function which accepts component's current **value** as a parameter. It is called when you are using the `value` props and the component's value changes. This prop is used to implement the [controlled component](https://reactjs.org/docs/forms/#controlled-components) behavior.
 -   **onError** `Function` [optional]
     gets triggered in case of an error and provides the `error` object, which can be used for debugging or giving feedback to the user if needed.
+-   **enableStrictSelection** `Boolean` [optional]
+    When set to `true`, a selected option can't be unselected. Although, it is possible to change the selected option. Defaults to `false`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/vue/list/SingleList.md
+++ b/content/docs/reactivesearch/vue/list/SingleList.md
@@ -199,6 +199,9 @@ export default {
 -   **transformData** `Function` [optional]
     allows transforming the data to render inside the list. You can change the order, remove, or add items, transform their values with this method. It provides the data as param which is an array of objects of shape { key: <string>, doc_count: <number> } and expects you to return the array of objects of same shape.
 
+-   **enableStrictSelection** `Boolean` [optional]
+    When set to `true`, a selected option can't be unselected. Although, it is possible to change the selected option. Defaults to `false`.
+
 ## Demo
 
 <br />


### PR DESCRIPTION
- `enableStrictSelection` prop usage added for the following components 

- ReactiveSearch (web) -
  - `SingleList`
  - `SingleDataList`
  Please go through the following PR for further reference - https://github.com/appbaseio/reactivesearch/pull/1707
  
- ReactiveSearch (Vue) -
  - `SingleList`
  Please go through the following PR for further reference - https://github.com/appbaseio/reactivesearch/pull/1708