### PR TITLE
feat: added reset_to_default prop for RS: web and vue

### DIFF
--- a/content/docs/reactivesearch/v3/advanced/selectedfilters.md
+++ b/content/docs/reactivesearch/v3/advanced/selectedfilters.md
@@ -61,7 +61,7 @@ Example uses:
 />
 ```
 -   **resetToDefault** `boolean` [optional]
-    When set to true and clearAll functionality is utilised, then it would set the filter's value to its default set value instead of null/ undefined.
+    When set to true and clearAll functionality is utilised, then it would set the filter's value to its default set value(the `defaultValue` prop) instead of null/ undefined.
     Defaults to `false`.
     
 Most ReactiveSearch filter components have a prop `showFilter` (defaults to `true`) which can be used to control whether the component's selected state appears in the SelectedFilters component. There is also a `filterLabel` prop which controls how that component is displayed.

--- a/content/docs/reactivesearch/v3/advanced/selectedfilters.md
+++ b/content/docs/reactivesearch/v3/advanced/selectedfilters.md
@@ -60,7 +60,10 @@ Example uses:
 	}}
 />
 ```
-
+-   **resetToDefault** `boolean` [optional]
+    When set to true and clearAll functionality is utilised, then it would set the filter's value to its default set value instead of null/ undefined.
+    Defaults to `false`.
+    
 Most ReactiveSearch filter components have a prop `showFilter` (defaults to `true`) which can be used to control whether the component's selected state appears in the SelectedFilters component. There is also a `filterLabel` prop which controls how that component is displayed.
 
 > Note

--- a/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
+++ b/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
@@ -47,6 +47,9 @@ Example uses:
     Sets the label for the clear all button.
 -   **title** `string` [optional]
     Can be used to set a title
+-   **resetToDefault** `boolean` [optional]
+    When set to true and clearAll functionality is utilised, then it would set the filter's value to its default set value instead of null/ undefined.
+    Defaults to `false`.
 
 Most ReactiveSearch filter components have a prop `showFilter` (defaults to `true`) which can be used to control whether the component's selected state appears in the SelectedFilters component. There is also a `filterLabel` prop which controls how that component is displayed.
 

--- a/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
+++ b/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
@@ -48,7 +48,7 @@ Example uses:
 -   **title** `string` [optional]
     Can be used to set a title
 -   **resetToDefault** `boolean` [optional]
-    When set to true and clearAll functionality is utilised, then it would set the filter's value to its default set value instead of null/ undefined.
+    When set to true and clearAll functionality is utilised, then it would set the filter's value to its default set value(the `defaultValue` prop) instead of null/ undefined.
     Defaults to `false`.
 
 Most ReactiveSearch filter components have a prop `showFilter` (defaults to `true`) which can be used to control whether the component's selected state appears in the SelectedFilters component. There is also a `filterLabel` prop which controls how that component is displayed.


### PR DESCRIPTION
**Description** : resetToDefault prop added to SelectedFiltes component in RS: web and vue in regard to [issue opened ](https://github.com/appbaseio/reactivesearch/issues/1722).


[Notio Card](https://www.notion.so/appbase/ReactiveSearch-SelectedFilters-reset-to-default-value-99d4a8a722f14947ab41c33a18ee5312)

[Loom Demo](https://www.loom.com/share/8eae8873854d465190dadd169ba6712c)

[Implementation PR Link](https://github.com/appbaseio/reactivesearch/pull/1725)


Libraries Affected 👍 
- RS: WEB
- RS: VUE
