### PR TITLE
react search-box controlled props example added

### DIFF
--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -185,7 +185,7 @@ Here, we are specifying that the suggestions should update whenever one of the b
 -   **value** `string` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `onChange` prop.
 
--   **onChange** `function` [optional]
+-   **onChange** `Function` [optional]
     is a callback function which accepts component's current **value** as a parameter. It is called when you are using the `value` prop and the component's value changes. This prop is used to implement the [controlled component](https://reactjs.org/docs/forms.html/#controlled-components) behavior.
 
     ```js

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -182,6 +182,32 @@ Here, we are specifying that the suggestions should update whenever one of the b
 />
 ```
 
+-   **value** `string` [optional]
+    sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `onChange` prop.
+
+-   **onChange** `function` [optional]
+    is a callback function which accepts component's current **value** as a parameter. It is called when you are using the `value` prop and the component's value changes. This prop is used to implement the [controlled component](https://reactjs.org/docs/forms.html/#controlled-components) behavior.
+
+    ```js
+    <SearchBox
+    	value={this.state.text}
+    	onChange={(value, searchComponent, e) => {
+    		// Perform actions after updating the value
+    		this.setState(
+    			{
+    				text: value,
+    			},
+    			() => {
+    				// To fetch suggestions
+    				searchComponent.triggerDefaultQuery();
+    				// To update results
+    				searchComponent.triggerCustomQuery();
+    			},
+    		);
+    	}}
+    />
+    ```
+
 ### To customize the AutoSuggestions
 
 -   **enablePopularSuggestions** `Boolean`


### PR DESCRIPTION
- controlled props usage added:
  - `value`
  - `onChange`
- For further reference please look into the following PR - https://github.com/appbaseio/searchbox/pull/103