### PR TITLE
feat: update dataField and fieldWeights docs

### DIFF
--- a/content/docs/analytics/google-analytics.md
+++ b/content/docs/analytics/google-analytics.md
@@ -77,7 +77,6 @@ Check the API docs for `React SearchBox` over [here](https://docs.appbase.io/doc
 	app="good-books-ds"
 	credentials="nY6NNTZZ6:27b76b9f-18ea-456c-bc5e-3a5263ebc63d"
 	dataField={['original_title', 'original_title.search']}
-	dataField
 	onValueChange={(next, prev) => {
 		if (prev !== next) {
 			window.ga('set', 'page', `/?query=${next}`);

--- a/content/docs/analytics/popular-suggestions.md
+++ b/content/docs/analytics/popular-suggestions.md
@@ -169,8 +169,16 @@ const Main = () => (
         <div className="col">
             <DataSearch
                 title="DataSearch"
-                dataField={["key", "key.autosuggest"]}
-				fieldWeights={[3, 1]}
+				dataField={[
+					{
+						"field": "key",
+						"weight": 3
+					},
+					{
+						"field": "key.autosuggest",
+						"weight": 1
+					},
+				]}
                 componentId="SearchComponent"
             />
         </div>

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -115,8 +115,8 @@ class HomePage extends StatelessWidget {
                         maxPopularSuggestions: 3,
                         size: 10,
                         dataField: [
-                          {'field': 'original_title', 'weight': 1},
-                          {'field': 'original_title.search', 'weight': 3}
+                          {'field': 'original_title', 'weight': 1 },
+                          {'field': 'original_title.search', 'weight': 3 }
                         ],
                         // This prop is used to return only the distinct value documents for the specified field
                         distinctField: 'authors.keyword',
@@ -433,8 +433,8 @@ class HomePage extends StatelessWidget {
                           maxPopularSuggestions: 3,
                           size: 10,
                           dataField: [
-                            {'field': 'original_title', 'weight': 1},
-                            {'field': 'original_title.search', 'weight': 3}
+                            {'field': 'original_title', 'weight': 1 },
+                            {'field': 'original_title.search', 'weight': 3 }
                           ],
                         ));
                   }),

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -434,7 +434,7 @@ class HomePage extends StatelessWidget {
                           size: 10,
                           dataField: [
                             {'field': 'original_title', 'weight': 1},
-                            {'field': 'original_title.search', 'weight': 3 }
+                            {'field': 'original_title.search', 'weight': 3}
                           ],
                         ));
                   }),

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -116,7 +116,7 @@ class HomePage extends StatelessWidget {
                         size: 10,
                         dataField: [
                           {'field': 'original_title', 'weight': 1},
-                          {'field': 'original_title.search', 'weight': 3 }
+                          {'field': 'original_title.search', 'weight': 3}
                         ],
                         // This prop is used to return only the distinct value documents for the specified field
                         distinctField: 'authors.keyword',

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -115,7 +115,7 @@ class HomePage extends StatelessWidget {
                         maxPopularSuggestions: 3,
                         size: 10,
                         dataField: [
-                          {'field': 'original_title', 'weight': 1 },
+                          {'field': 'original_title', 'weight': 1},
                           {'field': 'original_title.search', 'weight': 3 }
                         ],
                         // This prop is used to return only the distinct value documents for the specified field

--- a/content/docs/reactivesearch/flutter-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/flutter-searchbox/quickstart.md
@@ -433,7 +433,7 @@ class HomePage extends StatelessWidget {
                           maxPopularSuggestions: 3,
                           size: 10,
                           dataField: [
-                            {'field': 'original_title', 'weight': 1 },
+                            {'field': 'original_title', 'weight': 1},
                             {'field': 'original_title.search', 'weight': 3 }
                           ],
                         ));

--- a/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
@@ -56,7 +56,7 @@ The following properties can be used to configure the appbase.io [ReactiveSearch
     This property represents the type of the query which is defaults to `search`, valid values are `search`, `term`, `range` & `geo`. You can read more [here](/docs/search/reactivesearch-api/implement/#type-of-queries).
 
 -   **dataField** `string | Array<string | DataField>`
-    index field(s) to be connected to the component’s UI view. DataSearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
+    index field(s) to be connected to the component’s UI view. SearchBox accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
     Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
     You can define the `dataField` property as an array of objects of the `DataField` type to set the field weights.<br/>
     The `DataField` type has the following shape:

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -56,7 +56,7 @@ The following properties can be used to configure the appbase.io [ReactiveSearch
     This property represents the type of the query which is defaults to `search`, valid values are `search`, `term`, `range` & `geo`. You can read more [here](/docs/search/reactivesearch-api/implement/#type-of-queries).
 
 -   **dataField** `string | Array<string | DataField>`
-    index field(s) to be connected to the component’s UI view. DataSearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
+    index field(s) to be connected to the component’s UI view. SearchBox accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
     Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
     You can define the `dataField` property as an array of objects of the `DataField` type to set the field weights.<br/>
     The `DataField` type has the following shape:

--- a/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
+++ b/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
@@ -63,7 +63,7 @@ The following properties can be used to configure the appbase.io [ReactiveSearch
     This property represents the type of the query which is defaults to `search`, valid values are `search`, `term`, `range` & `geo`. You can read more [here](/docs/search/reactivesearch-api/implement/#type-of-queries).
 
 -   **dataField** `string | Array<string | DataField>`
-    index field(s) to be connected to the component’s UI view. DataSearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
+    index field(s) to be connected to the component’s UI view. SearchComponent accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
     Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
     You can define the `dataField` property as an array of objects of the `DataField` type to set the field weights.<br/>
     The `DataField` type has the following shape:

--- a/content/docs/reactivesearch/v3/overview/quickstart.md
+++ b/content/docs/reactivesearch/v3/overview/quickstart.md
@@ -114,17 +114,28 @@ Lets add them within the ReactiveBase component. But before we do that, we will 
 <DataSearch
 	componentId="searchbox"
 	dataField={[
-		"authors",
-		"authors.autosuggest",
-		"original_title",
-		"original_title.autosuggest"
+		{
+			"field": "authors",
+			"weight": 3
+		},
+		{
+			"field": "authors.autosuggest",
+			"weight": 1
+		},
+		{
+			"field": "original_title",
+			"weight": 5
+		},
+		{
+			"field": "original_title.autosuggest",
+			"weight": 1
+		},
 	]}
-	fieldWeights={[3, 1, 5, 1]}
 	placeholder="Search for books or authors"
 />
 ```
 
-The [**DataSearch**](/docs/reactivesearch/v3/search/datasearch/) component creates a searchbox UI component that queries on the specified fields with weights as specified by `fieldWeights` prop. That's all it takes to create a functional search component.
+The [**DataSearch**](/docs/reactivesearch/v3/search/datasearch/) component creates a searchbox UI component that queries on the specified fields with weights as specified by `dataField` prop. That's all it takes to create a functional search component.
 
 At this point, you should see the following:
 

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -37,14 +37,22 @@ Example uses:
 ```js
 <CategorySearch
 	componentId="SearchSensor"
-	dataField={['group_venue', 'group_city']}
+    dataField={[
+		{
+			"field": "group_venue",
+			"weight": 1
+		},
+		{
+			"field": "group_city",
+			"weight": 3
+		}
+	]}
 	categoryField="group_topics"
 	title="Search"
 	defaultValue={{
 		term: 'Paris',
 		category: '*',
 	}}
-	fieldWeights={[1, 3]}
 	placeholder="Search for cities or venues"
 	autoSuggest={true}
 	defaultSuggestions={[{ label: 'Programming', value: 'Programming' }]}
@@ -67,11 +75,24 @@ Example uses:
 
 -   **componentId** `String`
     unique identifier of the component, can be referenced in other components' `react` prop.
--   **dataField** `String or Array` [optional*]
-    database field(s) to be queried against. Accepts an Array in addition to String, useful for applying search across multiple fields.
->   Note:
->   This prop is optional only when `enableAppbase` prop is set to `true` in `ReactiveBase` component.
->
+-   **dataField** `string | Array<string | DataField*>` [optional*]
+    index field(s) to be connected to the component’s UI view. CategorySearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
+    Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
+    You can define the `dataField` property as an array of objects of the `DataField` type to set the field weights.<br/>
+    The `DataField` type has the following shape:
+
+    ```ts
+    type DataField = {
+    	field: string;
+    	weight: number;
+    };
+    ```
+    database field(s) to be queried against. Accepts an Array in addition to String, useful for applying search across multiple fields. Check examples at [here](/docs/search/reactivesearch-api/reference/#datafield).
+
+    > Note:
+    > 1. This prop is optional only when `enableAppbase` prop is set to `true` in `ReactiveBase` component.
+    > 2. The `dataField` property as `DataField` object is only available for ReactiveSearch version >= `v3.21.0` and Appbase version `v7.47.0`.
+
 -   **size** `Number` [optional]
     number of suggestions to show. Defaults to `10`.
 -   **aggregationField** `String` [optional]
@@ -118,14 +139,14 @@ Example uses:
 
 -   **onChange** `function` [optional]
     is a callback function which accepts component's current **value** as a parameter. It is called when you are using the `value` prop and the component's value changes. This prop is used to implement the [controlled component](https://reactjs.org/docs/forms.html/#controlled-components) behavior.
-    ```js
-    <CategorySearch
-    	value={this.state.value}
-    	onChange={(value, triggerQuery, event) => {
-    		this.setState({ value }, () => triggerQuery());
-    	}}
-    />
-    ```
+```jsx
+<CategorySearch
+    value={this.state.value}
+    onChange={(value, triggerQuery, event) => {
+        this.setState({ value }, () => triggerQuery());
+    }}
+/>
+```
     > Note: If you're using the controlled behavior than it's your responsibility to call the `triggerQuery` method to update the query i.e execute the search query and update the query results in connected components by `react` prop. It is not mandatory to call the `triggerQuery` in `onChange` you can also call it in other input handlers like `onBlur` or `onKeyPress`.
 -   **enableSynonyms** `bool` [optional]
     Defaults to `true`, can be used to `disable/enable` the synonyms behavior for the search query. Read more about it [here](/docs/search/reactivesearch-api/reference/#enablesynonyms)
@@ -147,8 +168,12 @@ Example uses:
 
 -   **downShiftProps** `Object` [optional]
     allow passing props directly to the underlying `Downshift` component. You can read more about Downshift props [here](https://github.com/paypal/downshift#--downshift-------).
--   **fieldWeights** `Array` [optional]
+
+-   **fieldWeights** `Array` [optional] <mark color="yellow">[deprecated]</mark>
     set the search weight for the database fields, useful when dataField is an Array of more than one field. This prop accepts an array of numbers. A higher number implies a higher relevance weight for the corresponding field in the search results.
+
+> Note: The `fieldWeights` property has been marked as deprecated in <b>v3.21.0</b> of ReactiveSearch and <b>v7.47.0</b> of Appbase and would be removed in the next major release. We recommend you to use the [dataField](/docs/search/reactivesearch-api/reference/#datafield) property to define the weights.
+
 -   **placeholder** `String` [optional]
     set placeholder text to be shown in the component's input field. Defaults to "Search".
 -   **showIcon** `Boolean` [optional]

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -175,7 +175,7 @@ Example uses:
 -   **fieldWeights** `Array` [optional] <mark color="yellow">[deprecated]</mark>
     set the search weight for the database fields, useful when dataField is an Array of more than one field. This prop accepts an array of numbers. A higher number implies a higher relevance weight for the corresponding field in the search results.
 
-> Note: The `fieldWeights` property has been marked as deprecated in <b>v3.21.0</b> of ReactiveSearch and <b>v7.47.0</b> of Appbase and would be removed in the next major release. We recommend you to use the [dataField](/docs/search/reactivesearch-api/reference/#datafield) property to define the weights.
+> Note: The `fieldWeights` property has been marked as deprecated in <b>v3.21.0</b> of ReactiveSearch and <b>v7.47.0</b> of appbase.io and would be removed in the next major release. We recommend you to use the [dataField](/docs/search/reactivesearch-api/reference/#datafield) property to define the weights.
 
 -   **placeholder** `String` [optional]
     set placeholder text to be shown in the component's input field. Defaults to "Search".

--- a/content/docs/reactivesearch/v3/search/categorysearch.md
+++ b/content/docs/reactivesearch/v3/search/categorysearch.md
@@ -147,7 +147,10 @@ Example uses:
     }}
 />
 ```
-    > Note: If you're using the controlled behavior than it's your responsibility to call the `triggerQuery` method to update the query i.e execute the search query and update the query results in connected components by `react` prop. It is not mandatory to call the `triggerQuery` in `onChange` you can also call it in other input handlers like `onBlur` or `onKeyPress`.
+> Note:
+>
+> If you're using the controlled behavior than it's your responsibility to call the `triggerQuery` method to update the query i.e execute the search query and update the query results in connected components by `react` prop. It is not mandatory to call the `triggerQuery` in `onChange` you can also call it in other input handlers like `onBlur` or `onKeyPress`.
+
 -   **enableSynonyms** `bool` [optional]
     Defaults to `true`, can be used to `disable/enable` the synonyms behavior for the search query. Read more about it [here](/docs/search/reactivesearch-api/reference/#enablesynonyms)
     > Note:

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -33,10 +33,18 @@ Example uses:
 ```js
 <DataSearch
 	componentId="SearchSensor"
-	dataField={['group_venue', 'group_city']}
+    dataField={[
+		{
+			"field": "group_venue",
+			"weight": 1
+		},
+		{
+			"field": "group_city",
+			"weight": 3
+		}
+	]}
 	title="Search"
 	defaultValue="Songwriting"
-	fieldWeights={[1, 3]}
 	placeholder="Search for cities or venues"
 	autosuggest={true}
 	defaultSuggestions={[
@@ -62,11 +70,23 @@ Example uses:
 
 -   **componentId** `String`
     unique identifier of the component, can be referenced in other components' `react` prop.
--   **dataField** `String or Array` [optional*]
-    database field(s) to be queried against. Accepts an Array in addition to String, useful for applying search across multiple fields.
->   Note:
->   This prop is optional only when `enableAppbase` prop is set to `true` in `ReactiveBase` component.
->
+-   **dataField** `string | Array<string | DataField*>` [optional*]
+    index field(s) to be connected to the component’s UI view. DataSearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
+    Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
+    You can define the `dataField` property as an array of objects of the `DataField` type to set the field weights.<br/>
+    The `DataField` type has the following shape:
+
+    ```ts
+    type DataField = {
+    	field: string;
+    	weight: number;
+    };
+    ```
+    database field(s) to be queried against. Accepts an Array in addition to String, useful for applying search across multiple fields. Check examples at [here](/docs/search/reactivesearch-api/reference/#datafield).
+
+    > Note:
+    > 1. This prop is optional only when `enableAppbase` prop is set to `true` in `ReactiveBase` component.
+    > 2. The `dataField` property as `DataField` object is only available for ReactiveSearch version >= `v3.21.0` and Appbase version `v7.47.0`.
 -   **size** `Number` [optional]
     number of suggestions to show. Defaults to `10`.
 -   **aggregationField** `String` [optional]
@@ -117,8 +137,9 @@ Example uses:
     Defaults to `false`. When set to `true`, it predicts the next relevant words from a field's value based on the search query typed by the user. When set to `false` (default), the entire field's value would be displayed. This may not be desirable for long-form fields (where average words per field value is greater than 4 and may not fit in a single line).
 -   **downShiftProps** `Object` [optional]
     allow passing props directly to the underlying `Downshift` component. You can read more about Downshift props [here](https://github.com/paypal/downshift#--downshift-------).
--   **fieldWeights** `Array` [optional]
+-   **fieldWeights** `Array` [optional] <mark color="yellow">[deprecated]</mark>
     set the search weight for the database fields, useful when dataField is an Array of more than one field. This prop accepts an array of numbers. A higher number implies a higher relevance weight for the corresponding field in the search results.
+> Note: The `fieldWeights` property has been marked as deprecated in <b>v3.21.0</b> of ReactiveSearch and <b>v7.47.0</b> of Appbase and would be removed in the next major release. We recommend you to use the [dataField](/docs/search/reactivesearch-api/reference/#datafield) property to define the weights.
 -   **placeholder** `String` [optional]
     set placeholder text to be shown in the component's input field. Defaults to "Search".
 -   **showIcon** `Boolean` [optional]

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -444,7 +444,7 @@ You can render popular suggestions in a custom layout by using the `renderQueryS
 
 > Note:
 >
-> If you're using the controlled behavior than it's your responsibility to call the `triggerQuery` method to update the query i.e execute the search query and update the query results in connected components by `react` prop. It is not mandatory to call the `triggerQuery` in `onChange` you can also call it in other input handlers like `onBlur` or `onKeyPress`.
+> If you're using the controlled behavior than it's your responsibility to call the `triggerQuery` method to update the query i.e execute the search query and update the query results in connected components by `react` prop. It is not mandatory to call the `triggerQuery` in `onChange` you can also call it in other input handlers like `onBlur` or `onKeyPress`. The `triggerQuery` method accepts an object with `isOpen` property (default to `false`) that can be used to control the opening state of the suggestion dropdown.
 
 -   **onSuggestions** `Function` [optional]
     You can pass a callback function to listen for the changes in suggestions. The function receives `suggestions` list.

--- a/content/docs/reactivesearch/vue/overview/QuickStart.md
+++ b/content/docs/reactivesearch/vue/overview/QuickStart.md
@@ -168,15 +168,26 @@ Lets add them within the ReactiveBase component. But before we do that, we will 
 	componentId="SearchBox"
 	placeholder="Search for books or authors"
 	:dataField="[
-		'authors',
-		'authors.autosuggest',
-		'original_title',
-		'original_title.autosuggest',
+		{
+			'field': 'authors',
+			'weight': 3
+		},
+		{
+			'field': 'authors.autosuggest',
+			'weight': 1
+		},
+		{
+			'field': 'original_title',
+			'weight': 5
+		},
+		{
+			'field': 'original_title.autosuggest',
+			'weight': 1
+		}
 	]"
-	:fieldWeights="[3, 1, 5, 1]"
 />
 ```
-The [data-search](/docs/reactivesearch/vue/search/DataSearch/) component creates a searchbox UI component that queries on the specified fields with weights as specified by `fieldWeights` prop. That's all it takes to create a functional search component.
+The [data-search](/docs/reactivesearch/vue/search/DataSearch/) component creates a searchbox UI component that queries on the specified fields with weights as specified by `dataField` prop. That's all it takes to create a functional search component.
 
 At this point, you should see the following:
 
@@ -280,12 +291,23 @@ Now, we will put all three components together to create the UI view.
         componentId="SearchBox"
         placeholder="Search for books or authors"
         :dataField="[
-          'authors',
-          'authors.autosuggest',
-          'original_title',
-          'original_title.autosuggest',
-        ]"
-        :fieldWeights="[3, 1, 5, 1]"
+			{
+				'field': 'authors',
+				'weight': 3
+			},
+			{
+				'field': 'authors.autosuggest',
+				'weight': 1
+			},
+			{
+				'field': 'original_title',
+				'weight': 5
+			},
+			{
+				'field': 'original_title.autosuggest',
+				'weight': 1
+			}
+		]"
       />
       <multi-list
         componentId="Authors"

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -743,7 +743,9 @@ The `suggestions` parameter receives all the unparsed suggestions from elasticse
           handleChange(value, triggerQuery, event) {
               this.value = value;
               // Trigger the search query to update the dependent components
-              triggerQuery()
+              triggerQuery({
+                isOpen: false // To close the suggestions dropdown; optional
+              })
           }
       }
   };
@@ -752,7 +754,7 @@ The `suggestions` parameter receives all the unparsed suggestions from elasticse
 
 > Note:
 >
-> If you're using the controlled behavior than it's your responsibility to call the `triggerQuery` method to update the query i.e execute the search query and update the query results in connected components by `react` prop. It is not mandatory to call the `triggerQuery` in `onChange` you can also call it in other input handlers like `onBlur` or `onKeyPress`.
+> If you're using the controlled behavior than it's your responsibility to call the `triggerQuery` method to update the query i.e execute the search query and update the query results in connected components by `react` prop. It is not mandatory to call the `triggerQuery` in `onChange` you can also call it in other input handlers like `onBlur` or `onKeyPress`. The `triggerQuery` method accepts an object with `isOpen` property (default to `false`) that can be used to control the opening state of the suggestion dropdown.
 
 - **queryChange**
   is an event which accepts component's **prevQuery** and **nextQuery** as parameters. It is called everytime the component's query changes. This event is handy in cases where you want to generate a side-effect whenever the component's query would change.

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -44,14 +44,30 @@ Example uses:
 	:autosuggest="true"
 	:highlight="true"
 	:showFilter="true"
-	:fieldWeights="[1, 3]"
+  :dataField="[
+			{
+				'field': 'group_venue',
+				'weight': 1
+			},
+			{
+				'field': 'group_city',
+				'weight': 3
+			},
+			{
+				'field': 'original_title',
+				'weight': 5
+			},
+			{
+				'field': 'original_title.autosuggest',
+				'weight': 1
+			}
+	]"
 	:fuzziness="0"
 	:size="10"
 	:debounce="100"
 	:react="{
     and: ['CategoryFilter', 'SearchFilter']
   }"
-	:dataField="['group_venue', 'group_city']"
 	:URLParams="false"
 />
 ```
@@ -60,11 +76,23 @@ Example uses:
 
 -   **componentId** `String`
     unique identifier of the component, can be referenced in other components' `react` prop.
--   **dataField** `String or Array` [optional*]
-    database field(s) to be queried against. Accepts an Array in addition to String, useful for applying search across multiple fields.
+-   **dataField** `string | Array<string | DataField*>` [optional*]
+    index field(s) to be connected to the component’s UI view. DataSearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
+    Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
+    You can define the `dataField` property as an array of objects of the `DataField` type to set the field weights.<br/>
+    The `DataField` type has the following shape:
+
+    ```ts
+    type DataField = {
+    	field: string;
+    	weight: number;
+    };
+    ```
+    database field(s) to be queried against. Accepts an Array in addition to String, useful for applying search across multiple fields. Check examples at [here](/docs/search/reactivesearch-api/reference/#datafield).
 
     > Note:
-    > This prop is optional only when `enableAppbase` prop is set to `true` in `ReactiveBase` component.
+    > 1. This prop is optional only when `enableAppbase` prop is set to `true` in `ReactiveBase` component.
+    > 2. The `dataField` property as `DataField` object is only available for ReactiveSearch version >= `v3.21.0` and Appbase version `v7.47.0`.
 
 -   **size** `Number` [optional]
     number of suggestions to show. Defaults to `10`.

--- a/content/docs/search/reactivesearch-api/reference.md
+++ b/content/docs/search/reactivesearch-api/reference.md
@@ -18,7 +18,7 @@ This guide helps you to learn more about the each property of `ReactiveSearch` A
 {
     query: [{
         id: "phone-search",
-        dataField: ["title"],
+        dataField: "title",
         size: 10,
         value: "iphone"
     }],
@@ -41,16 +41,67 @@ The unique identifier for the query can be referenced in the `react` property of
 
 ### dataField
 
-database field(s) to be queried against. Accepts an `Array`, useful for applying search across multiple fields.
+database field(s) to be queried against, useful for applying search across multiple fields.
+It accepts the following formats:
+- `string`
+- `DataField`
+- `Array<string|DataField>`
 
-| Type            | Applicable on query of type | Required |
-| --------------- | --------------------------- | -------- |
-| `Array<string>` | `all`                       | true     |
+The `DataField` type has the following shape:
+
+```ts
+type DataField = {
+    field: string;
+    weight: float;
+};
+```
+For examples,
+
+1. `dataField` without field weights
+```js
+    dataField: ['title', 'title.search']
+```
+
+2. `dataField` with field weights
+
+```js
+    dataField: [
+        {
+            "field": "title",
+            "weight": 1
+        },
+        {
+            "field": "title.search",
+            "weight": 3
+        }
+    ]
+```
+
+3. `dataField` with and without field weights
+
+```js
+    dataField: [
+        {
+            "field": "title",
+            "weight": 1
+        },
+        {
+            "field": "title.search",
+            "weight": 3
+        },
+        "description"
+    ]
+```
+
+
+| Type                                       | Applicable on query of type | Required |
+| ------------------------------------------ | --------------------------- | -------- |
+| `string | DataField | Array` | `all`                       | true     |
 
 > Note:
 > Multiple `dataFields` are not applicable for `term` and `geo` queries.
 
-### fieldWeights
+### fieldWeights [deprecated]
 
 To set the search weight for the database fields, useful when you are using more than one [dataField](/docs/search/reactivesearch-api/reference/#datafield). This prop accepts an array of `floats`. A higher number implies a higher relevance weight for the corresponding field in the search results.
 
@@ -71,6 +122,7 @@ For example, the below query has two data fields defined and each field has a di
 | ------------ | --------------------------- | -------- |
 | `Array<int>` | `search`                    | false    |
 
+> Note: The `fieldWeights` property has been marked as deprecated in <b>v7.47.0</b> and would be removed in the next major version of Appbase. We recommend you to use the [dataField](/docs/search/reactivesearch-api/reference/#datafield) property to define the weights.
 ### type
 
 This property represents the type of the query which is defaults to `search`, valid values are `search`, `term`, `range` & `geo`. You can read more [here](/docs/search/reactivesearch-api/implement/#type-of-queries).

--- a/content/docs/search/reactivesearch-api/reference.md
+++ b/content/docs/search/reactivesearch-api/reference.md
@@ -122,7 +122,7 @@ For example, the below query has two data fields defined and each field has a di
 | ------------ | --------------------------- | -------- |
 | `Array<int>` | `search`                    | false    |
 
-> Note: The `fieldWeights` property has been marked as deprecated in <b>v7.47.0</b> and would be removed in the next major version of Appbase. We recommend you to use the [dataField](/docs/search/reactivesearch-api/reference/#datafield) property to define the weights.
+> Note: The `fieldWeights` property has been marked as deprecated in <b>v7.47.0</b> and would be removed in the next major version of appbase.io. We recommend you to use the [dataField](/docs/search/reactivesearch-api/reference/#datafield) property to define the weights.
 ### type
 
 This property represents the type of the query which is defaults to `search`, valid values are `search`, `term`, `range` & `geo`. You can read more [here](/docs/search/reactivesearch-api/implement/#type-of-queries).


### PR DESCRIPTION
This PR performs the following changes:
- Mark `fieldWeights` property as deprecated
- Update `dataField` docs for FE libs and RS API reference
- Update code snippets to use new format to define field weights