### PR TITLE
enhancement: enhanced definitions for concerned events with associate…

### DIFF
--- a/content/docs/reactivesearch/vue/map/reactivegooglemap.md
+++ b/content/docs/reactivesearch/vue/map/reactivegooglemap.md
@@ -354,13 +354,13 @@ You can also check this [example](https://codesandbox.io/s/github/appbaseio/reac
     gets called when map is in idle position
 
 -   **open-marker-popover**
-    gets called when marker popover gets opened or marker is clicked
+    gets called when marker popover gets opened or marker is clicked, the current marker object is also emitted along.
 
 -   **close-marker-popover**
-    gets called when marker popover is closed
+    gets called when marker popover is closed, the current marker object is also emitted along.
 
 -   **open-cluster-popover**
-    gets called when cluster popover gets opened or cluster is clicked
+    gets called when cluster popover gets opened or cluster is clicked, an array of associated marker objects is also emitted along.
 
 -   **close-cluster-popover**
     gets called when cluster popover is closed


### PR DESCRIPTION
**PR TYPE:** `Enhancement`

**Description:** Enhanced docs stating the parameters emitted by the following events
   - [x]  `open-marker-popover` would return the current marker
   - [x]  `close-maker-popover` would return the current marker
   - [x]  `open-cluster-popover` would also return an array of markers for a particular cluster.
---

[🔗  Notion](https://www.notion.so/appbase/ReactiveMap-Vue-Provide-markers-data-in-events-06e6af009e9a41a4bb6d00353ebf4460)

[🔗  Implementation PR](https://github.com/appbaseio/reactivesearch/pull/1770)