### PR TITLE
fix: change format for value of range type query

### DIFF
--- a/content/docs/search/reactivesearch-api/reference.md
+++ b/content/docs/search/reactivesearch-api/reference.md
@@ -161,8 +161,8 @@ The value should be an `Object` in the following shape:
 
 ```js
 {
-   "start": int|string, // optional
-   "end": int|string, // optional
+   "start": int | double | date, // optional
+   "end": int | double | date, // optional
    "boost": int
 }
 ```


### PR DESCRIPTION
**PR Type**: `Bugfix`
**Description**: corrected the value prop format for the `range` type of queries.

![image](https://user-images.githubusercontent.com/57627350/135040703-c4aff9eb-a1be-44b4-974d-c7d66df8316c.png)
