### PR TITLE
feat(react/vue/mongo): added csb links for examples with updated lib

### DIFF
--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -27,6 +27,7 @@ url=https://us-east-1.aws.webhooks.mongodb-realm.com/api/client/v2.0/app/public-
 
 All of these examples can be deployed using MongoDB Realm's static hosting feature with one CLI command and a click. Read the Search UI hosting guide over [here](/docs/reactivesearch/atlas-search/static-hosting/).
 
+# with Searchbox
 ## Use Cases
 
 
@@ -168,7 +169,11 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-### Geo examples
+
+
+# with ReactiveSearch 
+
+### Geo example
 
 <iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Fmongo-support-reactivemaps/packages/maps/examples/mongo-examples/ReactiveMap?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
@@ -176,4 +181,33 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
+
+### DataSearch example
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/web/examples/mongo-examples/DataSearch?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="datasearch-example-mongo"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+### MultiList example
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/web/examples/mongo-examples/MultiList?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="multilist-example-mongo"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+### RangeInput example
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/web/examples/mongo-examples/RangeInput?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="rangeinput-example-mongo"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+
 

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -23,12 +23,13 @@ For this guide, we are making use of a publicly deployed Realm endpoint. You can
 url=https://us-east-1.aws.webhooks.mongodb-realm.com/api/client/v2.0/app/public-demo-skxjb/service/http_endpoint/incoming_webhook/reactivesearch
 ```
 
-> **Note:** Some of the examples make use of specific data types such as geopoint or autocomplete. These are already preset in the indexes they're queried against in these examples, but if you're replacing the Realm function endpoint, these data types need to be set prior to running the queries.
+> **Note:** Some of the examples make use of specific data types such as geopoint or autocomplete. These are already preset in the indexes they're queried against in these examples. However, if you're replacing the Realm function endpoint with your own, some data types need to be set prior to running the queries.
 
 All of these examples can be deployed using MongoDB Realm's static hosting feature with one CLI command and a click. Read the Search UI hosting guide over [here](/docs/reactivesearch/atlas-search/static-hosting/).
 
-# with Searchbox
-## Use Cases
+## With Searchbox
+
+Our first set of examples make use of the [React Searchbox](https://opensource.appbase.io/searchbox) library, a lightweight UI library focused on building search-as-you-type experiences. This library is lightweight primarily ships with a SearchBox component and provides a general purpose SearchComponent that can be used as a controller for any design component.
 
 
 ### Facet (list) examples
@@ -67,9 +68,6 @@ The `queryFormat` prop which accepts "or" or "and" as values allows setting whet
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-#### Passing MongoDB aggregation stages directly to override the default query of the term component
-
-TODO
 
 ### Search (typeahead) examples
 
@@ -171,9 +169,13 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 
 
-# with ReactiveSearch 
+## with ReactiveSearch
+
+Our next set of examples use [ReactiveSearch](https://opensource.appbase.io/reactivesearch), the most popular React UI kit for building search experiences. ReactiveSearch comes with over 20+ pre-built UI components, allowing you to build faceted, full-text and geo search use-cases with ease.
 
 ### Geo example
+
+Use [ReactiveGoogleMap](/docs/reactivesearch/v3/map/reactivegooglemap/) or [ReactiveOpenStreetMap](/docs/reactivesearch/v3/map/reactiveopenstreetmap/) components to power geo use-cases.
 
 <iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Fmongo-support-reactivemaps/packages/maps/examples/mongo-examples/ReactiveMap?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
@@ -184,6 +186,8 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### DataSearch example
 
+Use [DataSearch](/docs/reactivesearch/v3/search/datasearch/) component to power full-text search use-cases.
+
 <iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/web/examples/mongo-examples/DataSearch?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="datasearch-example-mongo"
@@ -193,6 +197,8 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### MultiList example
 
+Use [MultiList](/docs/reactivesearch/v3/list/multilist/) component to build faceted search experiences.
+
 <iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/web/examples/mongo-examples/MultiList?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="multilist-example-mongo"
@@ -201,6 +207,8 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
    ></iframe>
 
 ### RangeInput example
+
+Use [RangeInput](/docs/reactivesearch/v3/range/rangeinput/) component to add numeric facets to your search experience.
 
 <iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/web/examples/mongo-examples/RangeInput?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -37,7 +37,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 #### Getting the top buckets
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -48,7 +48,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 By default, the facet buckets are sorted by count. This example uses the `sortBy="asc"` prop to order the buckets in ascending order.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -59,7 +59,7 @@ By default, the facet buckets are sorted by count. This example uses the `sortBy
 
 The `queryFormat` prop which accepts "or" or "and" as values allows setting whether the results get filtered by an any ("or") matching clause or by an all ("and") matching clause. The following example uses the "and" value to filter Airbnb listings by those that satisfy all the selected amenities. 
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -91,7 +91,7 @@ dataField={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -119,7 +119,7 @@ defaultSuggestions={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -130,7 +130,7 @@ defaultSuggestions={[
 
 The `fuzziness` prop of Searchbox component enables finding matches even when the user input contains a typo.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=light&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=light&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -141,7 +141,7 @@ The `fuzziness` prop of Searchbox component enables finding matches even when th
 
 The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, but allows setting fields with autocomplete type to search on.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -152,7 +152,7 @@ The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, bu
 
 The `autosuggest` prop controls whether the autosuggestions UI is used or not. By setting it to false in this example, search is made on each keystroke.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -161,7 +161,7 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### Range examples
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -177,4 +177,3 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-TODO

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -37,7 +37,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 #### Getting the top buckets
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -48,7 +48,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 By default, the facet buckets are sorted by count. This example uses the `sortBy="asc"` prop to order the buckets in ascending order.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -59,7 +59,7 @@ By default, the facet buckets are sorted by count. This example uses the `sortBy
 
 The `queryFormat` prop which accepts "or" or "and" as values allows setting whether the results get filtered by an any ("or") matching clause or by an all ("and") matching clause. The following example uses the "and" value to filter Airbnb listings by those that satisfy all the selected amenities. 
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -91,7 +91,7 @@ dataField={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -119,7 +119,7 @@ defaultSuggestions={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -130,7 +130,7 @@ defaultSuggestions={[
 
 The `fuzziness` prop of Searchbox component enables finding matches even when the user input contains a typo.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=light&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=light&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -141,7 +141,7 @@ The `fuzziness` prop of Searchbox component enables finding matches even when th
 
 The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, but allows setting fields with autocomplete type to search on.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -152,7 +152,7 @@ The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, bu
 
 The `autosuggest` prop controls whether the autosuggestions UI is used or not. By setting it to false in this example, search is made on each keystroke.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -161,7 +161,7 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### Range examples
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -37,7 +37,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 #### Getting the top buckets
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -48,7 +48,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 By default, the facet buckets are sorted by count. This example uses the `sortBy="asc"` prop to order the buckets in ascending order.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -59,7 +59,7 @@ By default, the facet buckets are sorted by count. This example uses the `sortBy
 
 The `queryFormat` prop which accepts "or" or "and" as values allows setting whether the results get filtered by an any ("or") matching clause or by an all ("and") matching clause. The following example uses the "and" value to filter Airbnb listings by those that satisfy all the selected amenities. 
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -91,7 +91,7 @@ dataField={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -119,7 +119,7 @@ defaultSuggestions={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -130,7 +130,7 @@ defaultSuggestions={[
 
 The `fuzziness` prop of Searchbox component enables finding matches even when the user input contains a typo.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=light&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=light&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -141,7 +141,7 @@ The `fuzziness` prop of Searchbox component enables finding matches even when th
 
 The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, but allows setting fields with autocomplete type to search on.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -152,7 +152,7 @@ The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, bu
 
 The `autosuggest` prop controls whether the autosuggestions UI is used or not. By setting it to false in this example, search is made on each keystroke.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -161,7 +161,7 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### Range examples
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="@appbaseio/react-searchbox-demo-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -1,7 +1,7 @@
 ---
-title: 'Search examples with React Searchbox'
-meta_title: 'Search examples using React Searchbox'
-meta_description: 'Examples showing how to achieve different search use-cases with React Searchbox and Atlas Search'
+title: 'Search examples with React'
+meta_title: 'Search examples using React Searchbox and ReactiveSearch'
+meta_description: 'Examples showing how to achieve different search use-cases with React and Atlas Search'
 keywords:
     - overview
     - atlas-search
@@ -13,7 +13,7 @@ sidebar: 'docs'
 nestedSidebar: 'atlas-search'
 ---
 
-We will show how to build different kinds of search experiences with Atlas Search using the React Searchbox library.
+We will show how to build different kinds of search experiences with Atlas Search using the React Searchbox and ReactiveSearch libraries.
 
 The ReactiveSearch Realm function endpoint exposes a REST API that all of ReactiveSearch and Searchbox UI libraries use to express the declarative search intent. The ReactiveSearch API is documented over [here](https://docs.appbase.io/docs/search/reactivesearch-api/reference).
 
@@ -29,7 +29,7 @@ All of these examples can be deployed using MongoDB Realm's static hosting featu
 
 ## With Searchbox
 
-Our first set of examples make use of the [React Searchbox](https://opensource.appbase.io/searchbox) library, a lightweight UI library focused on building search-as-you-type experiences. This library is lightweight primarily ships with a SearchBox component and provides a general purpose SearchComponent that can be used as a controller for any design component.
+Our first set of examples make use of the [React Searchbox](https://opensource.appbase.io/searchbox) library, a lightweight UI library focused on building search-as-you-type experiences. This library is performant and lightweight (~30KB min+gzip size), comes with a pre-built SearchBox component and provides a general purpose SearchComponent that can be used to bind with any UI component.
 
 
 ### Facet (list) examples

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-react.md
@@ -170,4 +170,11 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### Geo examples
 
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Fmongo-support-reactivemaps/packages/maps/examples/mongo-examples/ReactiveMap?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="appbaseio/reactivesearch"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
 TODO

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
@@ -1,7 +1,7 @@
 ---
-title: 'Search examples with Vue Searchbox'
-meta_title: 'Search examples using Vue Searchbox'
-meta_description: 'Examples showing how to achieve different search use-cases with Vue Searchbox and Atlas Search'
+title: 'Search examples with Vue'
+meta_title: 'Search examples using Vue Searchbox and Vue ReactiveSearch'
+meta_description: 'Examples showing how to achieve different search use-cases with Vue Searchbox / ReactiveSearch and Atlas Search'
 keywords:
     - overview
     - atlas-search
@@ -13,7 +13,7 @@ sidebar: 'docs'
 nestedSidebar: 'atlas-search'
 ---
 
-We will show how to build different kinds of search experiences with Atlas Search using the Vue Searchbox library.
+We will show how to build different kinds of search experiences with Atlas Search using the Vue Searchbox and Vue ReactiveSearch libraries.
 
 The ReactiveSearch Realm function endpoint exposes a REST API that all of ReactiveSearch and Searchbox UI libraries use to express the declarative search intent. The ReactiveSearch API is documented over [here](https://docs.appbase.io/docs/search/reactivesearch-api/reference).
 
@@ -23,12 +23,13 @@ For this guide, we are making use of a publicly deployed Realm endpoint. You can
 url=https://us-east-1.aws.webhooks.mongodb-realm.com/api/client/v2.0/app/public-demo-skxjb/service/http_endpoint/incoming_webhook/reactivesearch
 ```
 
-> **Note:** Some of the examples make use of specific data types such as geopoint or autocomplete. These are already preset in the indexes they're queried against in these examples, but if you're replacing the Realm function endpoint, these data types need to be set prior to running the queries.
+> **Note:** Some of the examples make use of specific data types such as geopoint or autocomplete. These are already preset in the indexes they're queried against in these examples. However, if you're replacing the Realm function endpoint with your own, some data types need to be set prior to running the queries.
 
 All of these examples can be deployed using MongoDB Realm's static hosting feature with one CLI command and a click. Read the Search UI hosting guide over [here](/docs/reactivesearch/atlas-search/static-hosting/).
 
-# with Searchbox
-## Use Cases
+## With Searchbox
+
+Our first set of examples make use of the [Vue Searchbox](https://opensource.appbase.io/searchbox) library, a lightweight UI library focused on building search-as-you-type experiences. This library is lightweight primarily ships with a SearchBox component and provides a general purpose SearchComponent that can be used as a controller for any design component.
 
 
 ### Facet (list) examples
@@ -67,9 +68,6 @@ The `queryFormat` prop which accepts "or" or "and" as values allows setting whet
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-#### Passing MongoDB aggregation stages directly to override the default query of the term component
-
-TODO
 
 ### Search (typeahead) examples
 
@@ -169,7 +167,10 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-# with ReactiveSearch 
+## With ReactiveSearch 
+
+Our next set of examples use [Vue ReactiveSearch](https://opensource.appbase.io/reactivesearch/vue), the most popular Vue UI kit for building search experiences. ReactiveSearch comes with over 10+ pre-built UI components, allowing you to build faceted, numeric and full-text search use-cases with ease.
+
 
 ### DataSearch example
 
@@ -197,7 +198,3 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
-
-### Geo example
-
-TODO

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
@@ -37,7 +37,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 #### Getting the top buckets
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -48,7 +48,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 By default, the facet buckets are sorted by count. This example uses the `sortBy="asc"` prop to order the buckets in ascending order.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -59,7 +59,7 @@ By default, the facet buckets are sorted by count. This example uses the `sortBy
 
 The `queryFormat` prop which accepts "or" or "and" as values allows setting whether the results get filtered by an any ("or") matching clause or by an all ("and") matching clause. The following example uses the "and" value to filter Airbnb listings by those that satisfy all the selected amenities. 
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -91,7 +91,7 @@ dataField={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -119,7 +119,7 @@ defaultSuggestions={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -130,7 +130,7 @@ defaultSuggestions={[
 
 The `fuzziness` prop of Searchbox component enables finding matches even when the user input contains a typo.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -141,7 +141,7 @@ The `fuzziness` prop of Searchbox component enables finding matches even when th
 
 The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, but allows setting fields with autocomplete type to search on.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -152,7 +152,7 @@ The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, bu
 
 The `autosuggest` prop controls whether the autosuggestions UI is used or not. By setting it to false in this example, search is made on each keystroke.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -161,7 +161,7 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### Range examples
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
@@ -37,7 +37,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 #### Getting the top buckets
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -48,7 +48,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 By default, the facet buckets are sorted by count. This example uses the `sortBy="asc"` prop to order the buckets in ascending order.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -59,7 +59,7 @@ By default, the facet buckets are sorted by count. This example uses the `sortBy
 
 The `queryFormat` prop which accepts "or" or "and" as values allows setting whether the results get filtered by an any ("or") matching clause or by an all ("and") matching clause. The following example uses the "and" value to filter Airbnb listings by those that satisfy all the selected amenities. 
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -91,7 +91,7 @@ dataField={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -119,7 +119,7 @@ defaultSuggestions={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -130,7 +130,7 @@ defaultSuggestions={[
 
 The `fuzziness` prop of Searchbox component enables finding matches even when the user input contains a typo.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -141,7 +141,7 @@ The `fuzziness` prop of Searchbox component enables finding matches even when th
 
 The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, but allows setting fields with autocomplete type to search on.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -152,7 +152,7 @@ The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, bu
 
 The `autosuggest` prop controls whether the autosuggestions UI is used or not. By setting it to false in this example, search is made on each keystroke.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -161,7 +161,7 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### Range examples
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
@@ -29,8 +29,7 @@ All of these examples can be deployed using MongoDB Realm's static hosting featu
 
 ## With Searchbox
 
-Our first set of examples make use of the [Vue Searchbox](https://opensource.appbase.io/searchbox) library, a lightweight UI library focused on building search-as-you-type experiences. This library is lightweight primarily ships with a SearchBox component and provides a general purpose SearchComponent that can be used as a controller for any design component.
-
+Our first set of examples make use of the [Vue Searchbox](https://opensource.appbase.io/searchbox) library, a UI library focused on building search-as-you-type experiences. This library is performant and lightweight (~20KB min+gzip size), comes with a pre-built SearchBox component and provides a general purpose SearchComponent that can be used to bind with any UI component.
 
 ### Facet (list) examples
 

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
@@ -27,6 +27,7 @@ url=https://us-east-1.aws.webhooks.mongodb-realm.com/api/client/v2.0/app/public-
 
 All of these examples can be deployed using MongoDB Realm's static hosting feature with one CLI command and a click. Read the Search UI hosting guide over [here](/docs/reactivesearch/atlas-search/static-hosting/).
 
+# with Searchbox
 ## Use Cases
 
 
@@ -167,6 +168,36 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
-### Geo examples
+
+# with ReactiveSearch 
+
+### DataSearch example
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/vue/examples/mongo-examples/data-search?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="data-search-example-mongo"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+### MultiList example
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/vue/examples/mongo-examples/multi-list?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="multi-list-example-mongo"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+### RangeInput example
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/feat%2Frs-mongo-support/packages/vue/examples/mongo-examples/range-input?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="range-input-example-mongo"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+### Geo example
 
 TODO

--- a/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
+++ b/content/docs/reactivesearch/atlas-search/search-examples-with-vue.md
@@ -37,7 +37,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 #### Getting the top buckets
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/facet-filters?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -48,7 +48,7 @@ A single/multi select facet UI is typically represented with a term query. Here,
 
 By default, the facet buckets are sorted by count. This example uses the `sortBy="asc"` prop to order the buckets in ascending order.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/sort-facets?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -59,7 +59,7 @@ By default, the facet buckets are sorted by count. This example uses the `sortBy
 
 The `queryFormat` prop which accepts "or" or "and" as values allows setting whether the results get filtered by an any ("or") matching clause or by an all ("and") matching clause. The following example uses the "and" value to filter Airbnb listings by those that satisfy all the selected amenities. 
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/multi-select-facet-with-and-operator?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -91,7 +91,7 @@ dataField={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/search-with-field-weights?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -119,7 +119,7 @@ defaultSuggestions={[
 ]}
 ```
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/show-default-suggestions?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -130,7 +130,7 @@ defaultSuggestions={[
 
 The `fuzziness` prop of Searchbox component enables finding matches even when the user input contains a typo.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/fuzzy-search?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -141,7 +141,7 @@ The `fuzziness` prop of Searchbox component enables finding matches even when th
 
 The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, but allows setting fields with autocomplete type to search on.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/search-on-autocomplete-fields?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -152,7 +152,7 @@ The `autocompleteField` prop of Searchbox is similar to the `dataField` prop, bu
 
 The `autosuggest` prop controls whether the autosuggestions UI is used or not. By setting it to false in this example, search is made on each keystroke.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/show-result-on-each-search-keystroke?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -161,7 +161,7 @@ The `autosuggest` prop controls whether the autosuggestions UI is used or not. B
 
 ### Range examples
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/by-usecases/range-slider?fontsize=14&hidenavigation=1&theme=dark&view=preview"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="demo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/react-searchbox/examples.md
+++ b/content/docs/reactivesearch/react-searchbox/examples.md
@@ -30,7 +30,7 @@ This search component can be used to bind to different types of search UI widget
 
 In this example, we show the usage of some of the props that are available with the react-searchbox library like `autoSuggest`, `enablePopularSuggestions`, `enableRecentSearches`, `showVoiceSearch`, usage of `QueryRules` to get the promoted results.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/demo"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/demo"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-basic-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -41,7 +41,7 @@ In this example, we show the usage of some of the props that are available with 
 
 In this example, we show controlled usage with props like `value` & `onChange`, which are used in conjunction with several other props such as `onBlur`, `onKeyPress`, `focus`, `onValueSelected`, `onKeyDown`, `onKeyUp` and `onFocus` for gaining control of the searchbox. The mentioned props are used to control the behavior of the searchbox.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-controlled-props"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-controlled-props"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -52,31 +52,31 @@ In this example, we show controlled usage with props like `value` & `onChange`, 
 
 In this example, we show the usage of `react-table` to display the search results. The `SearchComponent` component is used to make the `result-component` reactively update by using the `react` prop when the dependent components, `author-filter` and `search-component` change their states. You can read more about the `react` prop over [here](/docs/reactivesearch/react-searchbox/searchcomponent/#to-configure-the-reactivesearch-api).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-react-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-react-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### DistinctField Prop Usage
 
 In this example, we show the usage of `distinctField` and `distinctFieldConfig` props. The `distinctField` prop is used to get distinct value documents for a specified field (`authors.keyword` in this case), the `distinctFieldConfig` prop is used to get the `inner_hits` object that contains the unique documents associated with this group (in this case, the other books by the same author).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### EnablePredictiveSuggestions Prop Usage
 
 In this example, we show the usage of the `enablePredictiveSuggestions` which when set to true, predicts the next relevant words from a field's value based on the search query.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### Index Prop Usage
 
 In this example, we show the usage of the `index` prop in the `author-search-component` to explicitly specify an index to query against for the component.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### TransformRequest Prop Usage
 
 In this example, we show the usage of the `transformRequest` prop, which gives us the request object whenever a query gets triggered. We then use this request object to extract the search query text and then make a call to an external API (datamuse) to get correct matching texts in case the search query was misspelled. The correct suggested text is then used to replace the misspelled query value in the request and then fire the query again, fetching relevant results even for misspelled queries.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-transform-request-prop"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-transform-request-prop"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-transform-request-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/react-searchbox/examples.md
+++ b/content/docs/reactivesearch/react-searchbox/examples.md
@@ -30,7 +30,7 @@ This search component can be used to bind to different types of search UI widget
 
 In this example, we show the usage of some of the props that are available with the react-searchbox library like `autoSuggest`, `enablePopularSuggestions`, `enableRecentSearches`, `showVoiceSearch`, usage of `QueryRules` to get the promoted results.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/demo"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/demo"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-basic-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -41,7 +41,7 @@ In this example, we show the usage of some of the props that are available with 
 
 In this example, we show controlled usage with props like `value` & `onChange`, which are used in conjunction with several other props such as `onBlur`, `onKeyPress`, `focus`, `onValueSelected`, `onKeyDown`, `onKeyUp` and `onFocus` for gaining control of the searchbox. The mentioned props are used to control the behavior of the searchbox.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/with-controlled-props"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-controlled-props"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -52,31 +52,31 @@ In this example, we show controlled usage with props like `value` & `onChange`, 
 
 In this example, we show the usage of `react-table` to display the search results. The `SearchComponent` component is used to make the `result-component` reactively update by using the `react` prop when the dependent components, `author-filter` and `search-component` change their states. You can read more about the `react` prop over [here](/docs/reactivesearch/react-searchbox/searchcomponent/#to-configure-the-reactivesearch-api).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/with-react-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-react-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### DistinctField Prop Usage
 
 In this example, we show the usage of `distinctField` and `distinctFieldConfig` props. The `distinctField` prop is used to get distinct value documents for a specified field (`authors.keyword` in this case), the `distinctFieldConfig` prop is used to get the `inner_hits` object that contains the unique documents associated with this group (in this case, the other books by the same author).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### EnablePredictiveSuggestions Prop Usage
 
 In this example, we show the usage of the `enablePredictiveSuggestions` which when set to true, predicts the next relevant words from a field's value based on the search query.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### Index Prop Usage
 
 In this example, we show the usage of the `index` prop in the `author-search-component` to explicitly specify an index to query against for the component.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### TransformRequest Prop Usage
 
 In this example, we show the usage of the `transformRequest` prop, which gives us the request object whenever a query gets triggered. We then use this request object to extract the search query text and then make a call to an external API (datamuse) to get correct matching texts in case the search query was misspelled. The correct suggested text is then used to replace the misspelled query value in the request and then fire the query again, fetching relevant results even for misspelled queries.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/react-searchbox/examples/with-transform-request-prop"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-transform-request-prop"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-transform-request-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/react-searchbox/examples.md
+++ b/content/docs/reactivesearch/react-searchbox/examples.md
@@ -30,7 +30,7 @@ This search component can be used to bind to different types of search UI widget
 
 In this example, we show the usage of some of the props that are available with the react-searchbox library like `autoSuggest`, `enablePopularSuggestions`, `enableRecentSearches`, `showVoiceSearch`, usage of `QueryRules` to get the promoted results.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/demo"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/demo"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-basic-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -41,7 +41,7 @@ In this example, we show the usage of some of the props that are available with 
 
 In this example, we show controlled usage with props like `value` & `onChange`, which are used in conjunction with several other props such as `onBlur`, `onKeyPress`, `focus`, `onValueSelected`, `onKeyDown`, `onKeyUp` and `onFocus` for gaining control of the searchbox. The mentioned props are used to control the behavior of the searchbox.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-controlled-props"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-controlled-props"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -52,31 +52,31 @@ In this example, we show controlled usage with props like `value` & `onChange`, 
 
 In this example, we show the usage of `react-table` to display the search results. The `SearchComponent` component is used to make the `result-component` reactively update by using the `react` prop when the dependent components, `author-filter` and `search-component` change their states. You can read more about the `react` prop over [here](/docs/reactivesearch/react-searchbox/searchcomponent/#to-configure-the-reactivesearch-api).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-react-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-react-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### DistinctField Prop Usage
 
 In this example, we show the usage of `distinctField` and `distinctFieldConfig` props. The `distinctField` prop is used to get distinct value documents for a specified field (`authors.keyword` in this case), the `distinctFieldConfig` prop is used to get the `inner_hits` object that contains the unique documents associated with this group (in this case, the other books by the same author).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### EnablePredictiveSuggestions Prop Usage
 
 In this example, we show the usage of the `enablePredictiveSuggestions` which when set to true, predicts the next relevant words from a field's value based on the search query.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### Index Prop Usage
 
 In this example, we show the usage of the `index` prop in the `author-search-component` to explicitly specify an index to query against for the component.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### TransformRequest Prop Usage
 
 In this example, we show the usage of the `transformRequest` prop, which gives us the request object whenever a query gets triggered. We then use this request object to extract the search query text and then make a call to an external API (datamuse) to get correct matching texts in case the search query was misspelled. The correct suggested text is then used to replace the misspelled query value in the request and then fire the query again, fetching relevant results even for misspelled queries.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/react-searchbox/examples/with-transform-request-prop"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/react-searchbox/examples/with-transform-request-prop"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="react-searchbox-transform-request-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/vue-searchbox/examples.md
+++ b/content/docs/reactivesearch/vue-searchbox/examples.md
@@ -30,7 +30,7 @@ This search component can be used to bind to different types of search UI widget
 
 In this example, we show the usage of some of the props that are available with the vue-searchbox library like `autoSuggest`, `enablePopularSuggestions`, `enableRecentSearches`, `showVoiceSearch`, usage of `QueryRules` to get the promoted results.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/demo"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/demo"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-basic-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -41,7 +41,7 @@ In this example, we show the usage of some of the props that are available with 
 
 In this example, we show controlled usage with props like `value` & `onChange`, which are used in conjunction with several other props such as `onBlur`, `onKeyPress`, `focus`, `onValueSelected`, `onKeyDown`, `onKeyUp` and `onFocus` for gaining control of the searchbox. The mentioned props are used to control the behavior of the searchbox.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/with-controlled-props"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-controlled-props"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -52,31 +52,31 @@ In this example, we show controlled usage with props like `value` & `onChange`, 
 
 In this example, we show the usage of `react-table` to display the search results. The `SearchComponent` component is used to make the `result-component` reactively update by using the `react` prop when the dependent components, `author-filter` and `search-component` change their states. You can read more about the `react` prop over [here](/docs/reactivesearch/react-searchbox/searchcomponent/#to-configure-the-reactivesearch-api).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/with-vue-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-vue-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### DistinctField Prop Usage
 
 In this example, we show the usage of `distinctField` and `distinctFieldConfig` props. The `distinctField` prop is used to get distinct value documents for a specified field (`authors.keyword` in this case), the `distinctFieldConfig` prop is used to get the `inner_hits` object that contains the unique documents associated with this group (in this case, the other books by the same author).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### EnablePredictiveSuggestions Prop Usage
 
 In this example, we show the usage of the `enablePredictiveSuggestions` which when set to true, predicts the next relevant words from a field's value based on the search query.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### Index Prop Usage
 
 In this example, we show the usage of the `index` prop in the `author-search-component` to explicitly specify an index to query against for the component.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### TransformRequest Prop Usage
 
 In this example, we show the usage of the `transformRequest` prop, which gives us the request object whenever a query gets triggered. We then use this request object to extract the search query text and then make a call to an external API (datamuse) to get correct matching texts in case the search query was misspelled. The correct suggested text is then used to replace the misspelled query value in the request and then fire the query again, fetching relevant results even for misspelled queries.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/master/packages/vue-searchbox/examples/with-transform-request-prop"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-transform-request-prop"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/vue-searchbox/examples.md
+++ b/content/docs/reactivesearch/vue-searchbox/examples.md
@@ -30,7 +30,7 @@ This search component can be used to bind to different types of search UI widget
 
 In this example, we show the usage of some of the props that are available with the vue-searchbox library like `autoSuggest`, `enablePopularSuggestions`, `enableRecentSearches`, `showVoiceSearch`, usage of `QueryRules` to get the promoted results.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/demo"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/demo"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-basic-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -41,7 +41,7 @@ In this example, we show the usage of some of the props that are available with 
 
 In this example, we show controlled usage with props like `value` & `onChange`, which are used in conjunction with several other props such as `onBlur`, `onKeyPress`, `focus`, `onValueSelected`, `onKeyDown`, `onKeyUp` and `onFocus` for gaining control of the searchbox. The mentioned props are used to control the behavior of the searchbox.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-controlled-props"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-controlled-props"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -52,31 +52,31 @@ In this example, we show controlled usage with props like `value` & `onChange`, 
 
 In this example, we show the usage of `react-table` to display the search results. The `SearchComponent` component is used to make the `result-component` reactively update by using the `react` prop when the dependent components, `author-filter` and `search-component` change their states. You can read more about the `react` prop over [here](/docs/reactivesearch/react-searchbox/searchcomponent/#to-configure-the-reactivesearch-api).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-vue-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-vue-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### DistinctField Prop Usage
 
 In this example, we show the usage of `distinctField` and `distinctFieldConfig` props. The `distinctField` prop is used to get distinct value documents for a specified field (`authors.keyword` in this case), the `distinctFieldConfig` prop is used to get the `inner_hits` object that contains the unique documents associated with this group (in this case, the other books by the same author).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### EnablePredictiveSuggestions Prop Usage
 
 In this example, we show the usage of the `enablePredictiveSuggestions` which when set to true, predicts the next relevant words from a field's value based on the search query.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### Index Prop Usage
 
 In this example, we show the usage of the `index` prop in the `author-search-component` to explicitly specify an index to query against for the component.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### TransformRequest Prop Usage
 
 In this example, we show the usage of the `transformRequest` prop, which gives us the request object whenever a query gets triggered. We then use this request object to extract the search query text and then make a call to an external API (datamuse) to get correct matching texts in case the search query was misspelled. The correct suggested text is then used to replace the misspelled query value in the request and then fire the query again, fetching relevant results even for misspelled queries.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-transform-request-prop"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-transform-request-prop"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/vue-searchbox/examples.md
+++ b/content/docs/reactivesearch/vue-searchbox/examples.md
@@ -30,7 +30,7 @@ This search component can be used to bind to different types of search UI widget
 
 In this example, we show the usage of some of the props that are available with the vue-searchbox library like `autoSuggest`, `enablePopularSuggestions`, `enableRecentSearches`, `showVoiceSearch`, usage of `QueryRules` to get the promoted results.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/demo"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/demo"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-basic-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -41,7 +41,7 @@ In this example, we show the usage of some of the props that are available with 
 
 In this example, we show controlled usage with props like `value` & `onChange`, which are used in conjunction with several other props such as `onBlur`, `onKeyPress`, `focus`, `onValueSelected`, `onKeyDown`, `onKeyUp` and `onFocus` for gaining control of the searchbox. The mentioned props are used to control the behavior of the searchbox.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-controlled-props"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-controlled-props"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -52,31 +52,31 @@ In this example, we show controlled usage with props like `value` & `onChange`, 
 
 In this example, we show the usage of `react-table` to display the search results. The `SearchComponent` component is used to make the `result-component` reactively update by using the `react` prop when the dependent components, `author-filter` and `search-component` change their states. You can read more about the `react` prop over [here](/docs/reactivesearch/react-searchbox/searchcomponent/#to-configure-the-reactivesearch-api).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-vue-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-vue-table" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### DistinctField Prop Usage
 
 In this example, we show the usage of `distinctField` and `distinctFieldConfig` props. The `distinctField` prop is used to get distinct value documents for a specified field (`authors.keyword` in this case), the `distinctFieldConfig` prop is used to get the `inner_hits` object that contains the unique documents associated with this group (in this case, the other books by the same author).
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-distinct-field-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### EnablePredictiveSuggestions Prop Usage
 
 In this example, we show the usage of the `enablePredictiveSuggestions` which when set to true, predicts the next relevant words from a field's value based on the search query.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-predictive-suggestions" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### Index Prop Usage
 
 In this example, we show the usage of the `index` prop in the `author-search-component` to explicitly specify an index to query against for the component.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-index-prop" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ### TransformRequest Prop Usage
 
 In this example, we show the usage of the `transformRequest` prop, which gives us the request object whenever a query gets triggered. We then use this request object to extract the search query text and then make a call to an external API (datamuse) to get correct matching texts in case the search query was misspelled. The correct suggested text is then used to replace the misspelled query value in the request and then fire the query again, fetching relevant results even for misspelled queries.
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/feat/update-examples-nov-2021/packages/vue-searchbox/examples/with-transform-request-prop"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/searchbox/tree/fix/issues-after-mongo-suggestion-merge/packages/vue-searchbox/examples/with-transform-request-prop"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="vue-searchbox-controlled-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"


### PR DESCRIPTION
**PR Type** `Feature`

**Description**
- Added updated CSB's for examples dependent upon searchbox libs (react/ vue).
- Added Geo example for Atlas React [here](https://docs.appbase.io/docs/reactivesearch/atlas-search/search-examples-with-react/#geo-examples).