### PR TITLE
Feat(rs-web-vue): add showclear prop for multi/single dropdown list

### DIFF
--- a/content/docs/reactivesearch/v3/list/multidropdownlist.md
+++ b/content/docs/reactivesearch/v3/list/multidropdownlist.md
@@ -111,6 +111,8 @@ function Index(props) {
     show count of number of occurences besides an item. Defaults to `true`.
 -   **showSearch** `Boolean` [optional]
     whether to show a searchbox to filter the list items locally. Defaults to `false`.
+-   **showClear** `Boolean` [optional]
+    whether to show a clear button to clear the entered text in the searchbox. Defaults to `false`.    
 -   **transformData** `Function` [optional]
     allows transforming the data to render inside the list. You can change the order, remove, or add items, tranform their values with this method. It provides the data as param which is an array of objects of shape `{ key: <string>, doc_count: <number> }` and expects you to return the array of objects of same shape.
 -   **showMissing** `Boolean` [optional]

--- a/content/docs/reactivesearch/v3/list/singledropdownlist.md
+++ b/content/docs/reactivesearch/v3/list/singledropdownlist.md
@@ -88,6 +88,8 @@ Example uses:
     show count of number of occurences besides an item. Defaults to `true`.
 -   **showSearch** `Boolean` [optional]
     whether to show a searchbox to filter the list items locally. Defaults to `false`.
+-   **showClear** `Boolean` [optional]
+    whether to show a clear button to clear the entered text in the searchbox. Defaults to `false`.    
 -   **showMissing** `Boolean` [optional]
     defaults to `false`. When set to `true` it also retrives the aggregations for missing fields under the label specified by `missingLabel`.
 -   **missingLabel** `String` [optional]

--- a/content/docs/reactivesearch/vue/list/MultiDropdownList.md
+++ b/content/docs/reactivesearch/vue/list/MultiDropdownList.md
@@ -94,6 +94,8 @@ Example uses:
     show count of number of occurences besides an item. Defaults to `true`.
 -   **showSearch** `Boolean` [optional]
     whether to show a searchbox to filter the list items locally. Defaults to false.
+-   **showClear** `Boolean` [optional]
+    whether to show a clear button to clear the entered text in the searchbox. Defaults to `false`.     
 -   **render** `Function|slot-scope` [optional]
     an alternative callback function to `renderItem`, where user can define how to render the view based on all the data changes.
     <br/>

--- a/content/docs/reactivesearch/vue/list/SingleDropdownList.md
+++ b/content/docs/reactivesearch/vue/list/SingleDropdownList.md
@@ -87,6 +87,8 @@ Example uses:
     show count of number of occurences besides an item. Defaults to `true`.
 -   **showSearch** `Boolean` [optional]
     whether to show a searchbox to filter the list items locally. Defaults to false.
+-   **showClear** `Boolean` [optional]
+    whether to show a clear button to clear the entered text in the searchbox. Defaults to `false`.    
 -   **renderItem** `Function|slot-scope` [optional]
     customize the rendered list via a function or slot-scope which receives the item label, count and isChecked & expects a JSX or String back. For example:
 


### PR DESCRIPTION
**PR Type** `Enhancement`

**Description** The PR adds prop definition for `showClear` prop in `MultiDropdownList`/ `SingleDropdownList` for web and vue libs.

**Implementation PR** https://github.com/appbaseio/reactivesearch/pull/1831