### PR TITLE
feat: support date types for range components

### DIFF
--- a/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
+++ b/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
@@ -111,8 +111,25 @@ While `DynamicRangeSlider` only requires the above props to be used, it comes wi
 -   **URLParams** `Boolean` [optional]
     enable creating a URL query string parameter based on the selected range of the slider. This is useful for sharing URLs with the component state. Defaults to `false`.
 -   **includeNullValues** `Boolean` [optional]
-    If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.
+    If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.    
+-   **queryFormat** `String`
+    Pass the `queryFormat` prop when dealing with date-type fields. Defaults to `date`. It sets the date format to be used in the query, can accept one of the following:
+<br />
 
+|              **queryFormat** | **Representation as [elasticsearch date](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats)** |
+| ---------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `epoch_millis` **(default)** |                                                                       `epoch_millis`                                                                       |
+|               `epoch_second` |                                                                       `epoch_second`                                                                       |
+|                 `basic_time` |                                                                       `HHmmss.SSSZ`                                                                        |
+|       `basic_time_no_millis` |                                                                         `HHmmssZ`                                                                          |
+|                       `date` |                                                                        `yyyy-MM-dd`                                                                        |
+|                 `basic_date` |                                                                         `yyyyMMdd`                                                                         |
+|            `basic_date_time` |                                                                  `yyyyMMdd'T'HHmmss.SSSZ`                                                                  |
+|  `basic_date_time_no_millis` |                                                                    `yyyyMMdd'T'HHmmssZ`                                                                    |
+|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
+> Note: `queryFormat` is mandatory to pass when dealing with date types.
+-   **calendarInterval** `String` [optional]
+    It sets the interval for aggreation-data when dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
+++ b/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
@@ -129,7 +129,7 @@ While `DynamicRangeSlider` only requires the above props to be used, it comes wi
 |        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
 -   **calendarInterval** `String` [optional]
-    It sets the interval for aggreation-data when dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
+    It sets the interval for aggreation-data when dealing with date-types. Default value is calculated internally based on the range - `start` and `end` values. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
+++ b/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
@@ -113,7 +113,7 @@ While `DynamicRangeSlider` only requires the above props to be used, it comes wi
 -   **includeNullValues** `Boolean` [optional]
     If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.    
 -   **queryFormat** `String`
-    Pass the `queryFormat` prop when dealing with date-type fields. Defaults to `date`. It sets the date format to be used in the query, can accept one of the following:
+    Set the date format to be used for querying data, default value is set to `date`. It can accept one of the following values: 
 <br />
 
 |              **queryFormat** | **Representation as [elasticsearch date](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats)** |

--- a/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
+++ b/content/docs/reactivesearch/v3/range/dynamicrangeslider.md
@@ -114,6 +114,7 @@ While `DynamicRangeSlider` only requires the above props to be used, it comes wi
     If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.    
 -   **queryFormat** `String`
     Set the date format to be used for querying data, default value is set to `date`. It can accept one of the following values: 
+
 <br />
 
 |              **queryFormat** | **Representation as [elasticsearch date](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats)** |
@@ -126,10 +127,15 @@ While `DynamicRangeSlider` only requires the above props to be used, it comes wi
 |                 `basic_date` |                                                                         `yyyyMMdd`                                                                         |
 |            `basic_date_time` |                                                                  `yyyyMMdd'T'HHmmss.SSSZ`                                                                  |
 |  `basic_date_time_no_millis` |                                                                    `yyyyMMdd'T'HHmmssZ`                                                                    |
-|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
+|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`                                                                  |
+
+
+
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
+
 -   **calendarInterval** `String` [optional]
     It sets the interval for aggreation-data when dealing with date-types. Default value is calculated internally based on the range - `start` and `end` values. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
+
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/rangeinput.md
+++ b/content/docs/reactivesearch/v3/range/rangeinput.md
@@ -77,6 +77,20 @@ Example uses:
     DB data field to be mapped with the component's UI view. The selected range creates a database query on this field.
 -   **range** `Object`
     an object with `start` and `end` keys and corresponding numeric values denoting the minimum and maximum possible slider values.
+    
+    `range` prop accepts `Date` objects as values corresponding to `start` and `end` keys when date-types are dealt with.
+
+    ```js
+        <RangeSlider
+            componentId="RangeSliderSensor"
+            dataField="guests"
+            title="Guests"
+            range={{
+                start: new Date('1980-12-12'),
+                end: new Date('2000-12-12'),
+            }}
+        />
+    ```
 -   **nestedField** `String` [optional]
     use to set the `nested` mapping field that allows arrays of objects to be indexed in a way that they can be queried independently of each other. Applicable only when dataField is a part of `nested` type.
 -   **title** `String or JSX` [optional]
@@ -115,7 +129,24 @@ Example uses:
     enable creating a URL query string parameter based on the selected value of the list. This is useful for sharing URLs with the component state. Defaults to `false`.
 -   **includeNullValues** `Boolean` [optional]
     If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.
+-   **queryFormat** `String`
+    Pass the `queryFormat` prop when dealing with date-type fields. Defaults to `date`. It sets the date format to be used in the query, can accept one of the following:
+<br />
 
+|              **queryFormat** | **Representation as [elasticsearch date](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats)** |
+| ---------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `epoch_millis` **(default)** |                                                                       `epoch_millis`                                                                       |
+|               `epoch_second` |                                                                       `epoch_second`                                                                       |
+|                 `basic_time` |                                                                       `HHmmss.SSSZ`                                                                        |
+|       `basic_time_no_millis` |                                                                         `HHmmssZ`                                                                          |
+|                       `date` |                                                                        `yyyy-MM-dd`                                                                        |
+|                 `basic_date` |                                                                         `yyyyMMdd`                                                                         |
+|            `basic_date_time` |                                                                  `yyyyMMdd'T'HHmmss.SSSZ`                                                                  |
+|  `basic_date_time_no_millis` |                                                                    `yyyyMMdd'T'HHmmssZ`                                                                    |
+|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
+> Note: `queryFormat` is mandatory to pass when dealing with date types.
+-   **calendarInterval** `String` [optional]
+    It sets the interval for aggreation-data when dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/rangeinput.md
+++ b/content/docs/reactivesearch/v3/range/rangeinput.md
@@ -78,7 +78,7 @@ Example uses:
 -   **range** `Object`
     an object with `start` and `end` keys and corresponding numeric values denoting the minimum and maximum possible slider values.
     
-    `range` prop accepts `Date` objects as values corresponding to `start` and `end` keys when date-types are dealt with.
+    `range` prop accepts (JavaScript) `Date` objects as values for the `start` and `end` keys when a date type field is used for the `dataField`.
 
     ```js
         <RangeInput

--- a/content/docs/reactivesearch/v3/range/rangeinput.md
+++ b/content/docs/reactivesearch/v3/range/rangeinput.md
@@ -147,7 +147,7 @@ Example uses:
 |        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
 -   **calendarInterval** `String` [optional]
-    sets the histogram bar interval, applicable dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
+    It sets the interval for aggreation-data when dealing with date-types. Default value is calculated internally based on the range - `start` and `end` values. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/rangeinput.md
+++ b/content/docs/reactivesearch/v3/range/rangeinput.md
@@ -81,14 +81,15 @@ Example uses:
     `range` prop accepts `Date` objects as values corresponding to `start` and `end` keys when date-types are dealt with.
 
     ```js
-        <RangeSlider
-            componentId="RangeSliderSensor"
-            dataField="guests"
-            title="Guests"
+        <RangeInput
+            componentId="RangeInputComponent"
+            dataField="timestamp"
+            title="Publication year"
             range={{
                 start: new Date('1980-12-12'),
                 end: new Date('2000-12-12'),
             }}
+            queryFormat="date"
         />
     ```
 -   **nestedField** `String` [optional]
@@ -146,7 +147,7 @@ Example uses:
 |        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
 -   **calendarInterval** `String` [optional]
-    It sets the interval for aggreation-data when dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
+    sets the histogram bar interval, applicable dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/rangeinput.md
+++ b/content/docs/reactivesearch/v3/range/rangeinput.md
@@ -132,6 +132,7 @@ Example uses:
     If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.
 -   **queryFormat** `String`
     Pass the `queryFormat` prop when dealing with date-type fields. Defaults to `date`. It sets the date format to be used in the query, can accept one of the following:
+
 <br />
 
 |              **queryFormat** | **Representation as [elasticsearch date](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats)** |
@@ -144,10 +145,13 @@ Example uses:
 |                 `basic_date` |                                                                         `yyyyMMdd`                                                                         |
 |            `basic_date_time` |                                                                  `yyyyMMdd'T'HHmmss.SSSZ`                                                                  |
 |  `basic_date_time_no_millis` |                                                                    `yyyyMMdd'T'HHmmssZ`                                                                    |
-|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
+|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`                                                                  |
+
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
+
 -   **calendarInterval** `String` [optional]
     It sets the interval for aggreation-data when dealing with date-types. Default value is calculated internally based on the range - `start` and `end` values. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
+    
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/rangeslider.md
+++ b/content/docs/reactivesearch/v3/range/rangeslider.md
@@ -136,6 +136,7 @@ While `RangeSlider` only requires the above props to be used, it comes with many
     If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.
 -   **queryFormat** `String`
     Pass the `queryFormat` prop when dealing with date-type fields. Defaults to `date`. It sets the date format to be used in the query, can accept one of the following:
+
 <br />
 
 |              **queryFormat** | **Representation as [elasticsearch date](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats)** |
@@ -148,11 +149,15 @@ While `RangeSlider` only requires the above props to be used, it comes with many
 |                 `basic_date` |                                                                         `yyyyMMdd`                                                                         |
 |            `basic_date_time` |                                                                  `yyyyMMdd'T'HHmmss.SSSZ`                                                                  |
 |  `basic_date_time_no_millis` |                                                                    `yyyyMMdd'T'HHmmssZ`                                                                    |
-|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
+|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`                                                                  |
+
 
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
+
 -   **calendarInterval** `String` [optional]
-    It sets the interval for aggreation-data when dealing with date-types. Default value is calculated internally based on the range - `start` and `end` values. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. ## Demo
+    It sets the interval for aggreation-data when dealing with date-types. Default value is calculated internally based on the range - `start` and `end` values. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
+    
+## Demo
 
 <br />
 

--- a/content/docs/reactivesearch/v3/range/rangeslider.md
+++ b/content/docs/reactivesearch/v3/range/rangeslider.md
@@ -77,6 +77,20 @@ While `RangeSlider` only requires the above props to be used, it comes with many
     DB data field to be mapped with the component's UI view. The selected range creates a database query on this field.
 -   **range** `Object`
     an object with `start` and `end` keys and corresponding numeric values denoting the minimum and maximum possible slider values.
+    
+    `range` prop accepts `Date` objects as values corresponding to `start` and `end` keys when date-types are dealt with.
+
+    ```js
+        <RangeSlider
+            componentId="RangeSliderSensor"
+            dataField="guests"
+            title="Guests"
+            range={{
+                start: new Date('1980-12-12'),
+                end: new Date('2000-12-12'),
+            }}
+        />
+    ```
 -   **nestedField** `String` [optional]
     use to set the `nested` mapping field that allows arrays of objects to be indexed in a way that they can be queried independently of each other. Applicable only when dataField is a part of `nested` type.
 -   **title** `String or JSX` [optional]
@@ -119,7 +133,25 @@ While `RangeSlider` only requires the above props to be used, it comes with many
     enable creating a URL query string parameter based on the selected value of the list. This is useful for sharing URLs with the component state. Defaults to `false`.
 -   **includeNullValues** `Boolean` [optional]
     If you have sparse data or document or items not having the value in the specified field or mapping, then this prop enables you to show that data. Defaults to `false`.
+-   **queryFormat** `String`
+    Pass the `queryFormat` prop when dealing with date-type fields. Defaults to `date`. It sets the date format to be used in the query, can accept one of the following:
+<br />
 
+|              **queryFormat** | **Representation as [elasticsearch date](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#built-in-date-formats)** |
+| ---------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `epoch_millis` **(default)** |                                                                       `epoch_millis`                                                                       |
+|               `epoch_second` |                                                                       `epoch_second`                                                                       |
+|                 `basic_time` |                                                                       `HHmmss.SSSZ`                                                                        |
+|       `basic_time_no_millis` |                                                                         `HHmmssZ`                                                                          |
+|                       `date` |                                                                        `yyyy-MM-dd`                                                                        |
+|                 `basic_date` |                                                                         `yyyyMMdd`                                                                         |
+|            `basic_date_time` |                                                                  `yyyyMMdd'T'HHmmss.SSSZ`                                                                  |
+|  `basic_date_time_no_millis` |                                                                    `yyyyMMdd'T'HHmmssZ`                                                                    |
+|        `date_time_no_millis` |                                                                 `yyyy-MM-dd'T'HH:mm:ssZZ`      
+
+> Note: `queryFormat` is mandatory to pass when dealing with date types.
+-   **calendarInterval** `String` [optional]
+    It sets the interval for aggreation-data when dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/range/rangeslider.md
+++ b/content/docs/reactivesearch/v3/range/rangeslider.md
@@ -152,8 +152,7 @@ While `RangeSlider` only requires the above props to be used, it comes with many
 
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
 -   **calendarInterval** `String` [optional]
-    sets the histogram bar interval, applicable dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
-## Demo
+    It sets the interval for aggreation-data when dealing with date-types. Default value is calculated internally based on the range - `start` and `end` values. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. ## Demo
 
 <br />
 

--- a/content/docs/reactivesearch/v3/range/rangeslider.md
+++ b/content/docs/reactivesearch/v3/range/rangeslider.md
@@ -83,12 +83,13 @@ While `RangeSlider` only requires the above props to be used, it comes with many
     ```js
         <RangeSlider
             componentId="RangeSliderSensor"
-            dataField="guests"
-            title="Guests"
+            dataField="timestamp"
+            title="Publication Year"
             range={{
                 start: new Date('1980-12-12'),
                 end: new Date('2000-12-12'),
             }}
+            queryFormat="date"            
         />
     ```
 -   **nestedField** `String` [optional]
@@ -151,7 +152,7 @@ While `RangeSlider` only requires the above props to be used, it comes with many
 
 > Note: `queryFormat` is mandatory to pass when dealing with date types.
 -   **calendarInterval** `String` [optional]
-    It sets the interval for aggreation-data when dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
+    sets the histogram bar interval, applicable dealing with date-types. Defaults to `month`. It can accept one of the following: `year`, `quarter`, `month`, `week`, `day`, `hour`, and `minute`. 
 ## Demo
 
 <br />


### PR DESCRIPTION
**PR Type** `Enhancement`

**Description** The PR extends the docs for Range Components adding prop def for use with date-types.

Props added
- queryFormat
- calendarInterval
- range (updated to support dates also)

Components Affected
- RangeSlider
- DynamicRangeSlider
- RangeInput

[Loom](https://www.loom.com/share/2b4ac0ba60ca4d8e8640c181984ff49f)

**Implementation PR** https://github.com/appbaseio/reactivesearch/pull/1825