### PR TITLE
feat(rs-web): added isOpen prop def for rs-web components

### DIFF
--- a/content/docs/reactivesearch/v3/list/multidropdownlist.md
+++ b/content/docs/reactivesearch/v3/list/multidropdownlist.md
@@ -241,6 +241,7 @@ Or you can also use render function as children
     The index prop can be used to explicitly specify an index to query against for this component. It is suitable for use-cases where you want to fetch results from more than one index in a single ReactiveSearch API request. The default value for the index is set to the `app` prop defined in the ReactiveBase component.
 
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
+-   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render.     Defaults to `false`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/v3/list/multidropdownlist.md
+++ b/content/docs/reactivesearch/v3/list/multidropdownlist.md
@@ -241,7 +241,7 @@ Or you can also use render function as children
     The index prop can be used to explicitly specify an index to query against for this component. It is suitable for use-cases where you want to fetch results from more than one index in a single ReactiveSearch API request. The default value for the index is set to the `app` prop defined in the ReactiveBase component.
 
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
--   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render.     Defaults to `false`.
+-   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
 
 ## Demo
 

--- a/content/docs/reactivesearch/v3/list/singledropdownlist.md
+++ b/content/docs/reactivesearch/v3/list/singledropdownlist.md
@@ -218,6 +218,8 @@ Or you can also use render function as children
 
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
 -   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render.     Defaults to `false`.
+
+
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/list/singledropdownlist.md
+++ b/content/docs/reactivesearch/v3/list/singledropdownlist.md
@@ -217,7 +217,7 @@ Or you can also use render function as children
     The index prop can be used to explicitly specify an index to query against for this component. It is suitable for use-cases where you want to fetch results from more than one index in a single ReactiveSearch API request. The default value for the index is set to the `app` prop defined in the ReactiveBase component.
 
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
--   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render.     Defaults to `false`.
+-   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
 
 
 ## Demo

--- a/content/docs/reactivesearch/v3/list/singledropdownlist.md
+++ b/content/docs/reactivesearch/v3/list/singledropdownlist.md
@@ -217,7 +217,7 @@ Or you can also use render function as children
     The index prop can be used to explicitly specify an index to query against for this component. It is suitable for use-cases where you want to fetch results from more than one index in a single ReactiveSearch API request. The default value for the index is set to the `app` prop defined in the ReactiveBase component.
 
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
-
+-   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render.     Defaults to `false`.
 ## Demo
 
 <br />

--- a/content/docs/reactivesearch/v3/search/searchbox.md
+++ b/content/docs/reactivesearch/v3/search/searchbox.md
@@ -782,6 +782,8 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
         />
     ```
 
+-   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
+
 ## Examples
 
 <a href="https://opensource.appbase.io/playground/?selectedKind=Search%20components%2FSearchBox" target="_blank">SearchBox with default props</a>


### PR DESCRIPTION
**PR Type** `Enhancement`

**Description**
The PR adds prop definition for `isOpen` prop for `Searchbox`, `SingleDropdownList` and `MultiDropdownList` components in lieu of supporting better snapshot tests.

**Related PR(s)**
- https://github.com/appbaseio/reactivesearch/pull/1833