### PR TITLE
feat(vue): adds def for isOpen prop in dropdown list components 

### DIFF
--- a/content/docs/reactivesearch/vue/list/MultiDropdownList.md
+++ b/content/docs/reactivesearch/vue/list/MultiDropdownList.md
@@ -248,7 +248,7 @@ export default {
     enable creating a URL query string parameter based on the selected value of the list. This is useful for sharing URLs with the component state. Defaults to `false`.
 -   **showLoadMore** `Boolean` [optional]
     defaults to `false` and works only with elasticsearch >= 6 since it uses [composite aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html). This adds a "Load More" button to load the aggs on demand combined with the `size` prop. Composite aggregations are in beta and this is an experimental API which might change in a future release.
-
+-   **isOpen** `Boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
 ## Demo
 
 <br/>

--- a/content/docs/reactivesearch/vue/list/SingleDropdownList.md
+++ b/content/docs/reactivesearch/vue/list/SingleDropdownList.md
@@ -209,6 +209,7 @@ You can use render as a slot as shown below:
 -   **showLoadMore** `Boolean` [optional]
     defaults to `false` and works only with elasticsearch >= 6 since it uses [composite aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html). This adds a "Load More" button to load the aggs on demand combined with the `size` prop. Composite aggregations are in beta and this is an experimental API which might change in a future release.
 
+-   **isOpen** `Boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
 ## Demo
 
 <br/>


### PR DESCRIPTION
**PR Type** `Enhancement`

**Description**
The PR adds prop definition for `isOpen` prop for  `SingleDropdownList` and `MultiDropdownList` components in lieu of supporting snapshot tests.

**Related PR(s)**
- https://github.com/appbaseio/reactivesearch/pull/1854