### PR TITLE
Credentials required

### DIFF
--- a/content/docs/reactivesearch/react-native-searchbox/searchbase.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbase.md
@@ -28,7 +28,7 @@ nestedSidebar: 'react-native-searchbox-reactivesearch'
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/react-native-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchbox.md
@@ -30,7 +30,7 @@ The below props are only needed if you're not using the `SearchBox` component un
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
@@ -35,7 +35,7 @@ The below props are only needed if you're not using the `SearchComponent` compon
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/react-searchbox/searchbase.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbase.md
@@ -28,7 +28,7 @@ nestedSidebar: 'react-searchbox-reactivesearch'
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -30,7 +30,7 @@ The below props are only needed if you're not using the `SearchBox` component un
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -35,7 +35,7 @@ The below props are only needed if you're not using the `SearchComponent` compon
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/searchbase/overview/searchbase.md
+++ b/content/docs/reactivesearch/searchbase/overview/searchbase.md
@@ -49,7 +49,7 @@ The following properties can be used to configure appbase.io environment globall
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object` [optional]
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
+++ b/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
@@ -42,7 +42,7 @@ const searchComponent = new SearchComponent(properties);
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [Required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/vue-searchbox/searchbase.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbase.md
@@ -28,7 +28,7 @@ nestedSidebar: 'vue-searchbox-reactivesearch'
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -30,7 +30,7 @@ The below props are only needed if you're not using the `SearchBox` component un
     URL for the Elasticsearch cluster
 
 -   **credentials** `String` [required]
-    Basic Auth credentials if required for authentication purposes. It should be a String of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a String of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:

--- a/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
@@ -35,7 +35,7 @@ The below props are only needed if you're not using the `SearchComponent` compon
     URL for the Elasticsearch cluster
 
 -   **credentials** `string` [required]
-    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard. If you are not using an appbase.io cluster, credentials may not be necessary - although having open access to your Elasticsearch cluster is not recommended.
+    Basic Auth credentials if required for authentication purposes. It should be a string of the format `username:password`. If you are using an appbase.io cluster, you will find credentials under the `Security > API credentials` section of the appbase.io dashboard.
 
 -   **appbaseConfig** `Object`
     allows you to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:


### PR DESCRIPTION
I was struggling to understand this part of the documentation. It seems conflicting about whether the credentials prop is required or not. It reads `**credentials** 'string' [required]` but that it might not be necessary. I haven't looked into the implementation, but I get an error when not providing `credentials` so I believe that it indeed is required and not optional as described in the text suggested for removal.