### PR TITLE
fix: searchbox description not showing when highlight text doesn't match

### DIFF
--- a/src/components/common/search/HomeSearch.js
+++ b/src/components/common/search/HomeSearch.js
@@ -127,7 +127,7 @@ const HitTemplate = ({ hit, currentValue }) => {
 	const highlightedTitle = hit.title.replace(new RegExp(currentValue, 'ig'), matched => {
 		return `<mark>${matched}</mark>`;
 	});
-	const tokens = hit.tokens.filter(item => item.includes(currentValue));
+	const tokens = hit.tokens;
 	let highlightedToken =
 		tokens[0] &&
 		tokens[0].replace(new RegExp(currentValue, 'ig'), matched => {

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1938,6 +1938,7 @@ tbody tr td:nth-child(-n + 3) {
 .autosuggest-footer-container {
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
 	color: #8792a2;
 	background: #f7fafc;
 	padding: 10px;


### PR DESCRIPTION
This PR fixes the searchbox description not showing when the search value isn't present in the description text. Suggestion description should show up regardless of it matching the search text.

**Before submitting a pull request,** please make sure that the following is done:

- [x] Describe the proposed changes and how it'll improve the docs experience
- [x] Please make sure that there are no indentation errors with rendering the docs
