### PR TITLE
feat: add doc ref for setCategoryValue setter 

### DIFF
--- a/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
@@ -579,6 +579,7 @@ Returns the current mic instance. Can be used to set mic language and other prop
 The following methods can be used to set or update the properties in the search state:
 
 -   **setValue** `( value: any, options?: Options ) => void`  can be used to set the `value` property
+-   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property
 -   **setSize** `( size: number, options?: Options ) => void`  can be used to set the `size` property
 -   **setFrom** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
 -   **setFuzziness** `( fuzziness: string|number, options?: Options ) => void` can be used to set the `fuzziness` property.

--- a/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-native-searchbox/searchcomponent.md
@@ -579,7 +579,7 @@ Returns the current mic instance. Can be used to set mic language and other prop
 The following methods can be used to set or update the properties in the search state:
 
 -   **setValue** `( value: any, options?: Options ) => void`  can be used to set the `value` property
--   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property
+-   **setCategoryValue** `(categoryValue: string, options?: Options) => void`  can be used to set the `categoryValue` property
 -   **setSize** `( size: number, options?: Options ) => void`  can be used to set the `size` property
 -   **setFrom** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
 -   **setFuzziness** `( fuzziness: string|number, options?: Options ) => void` can be used to set the `fuzziness` property.

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -564,6 +564,7 @@ Here, we are specifying that the suggestions should update whenever one of the b
     -   **`triggerCustomQuery`** `(options): Promise<any>` can be used to trigger the `defaultQuery` programmatically
     -   **`setDataField`** `( dataField: string | Array<string | DataField>, options?: Options ) => void`
     -   **`setValue`** `( value: any, options?: Options ) => void` can be used to set the `value` property
+    -   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property.
     -   **`setSize`** `( size: number, options?: Options ) => void` can be used to set the `size` property
     -   **`setFrom`** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
     -   **setAfter** `(after: object, options?: Options) => void`

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -564,7 +564,7 @@ Here, we are specifying that the suggestions should update whenever one of the b
     -   **`triggerCustomQuery`** `(options): Promise<any>` can be used to trigger the `defaultQuery` programmatically
     -   **`setDataField`** `( dataField: string | Array<string | DataField>, options?: Options ) => void`
     -   **`setValue`** `( value: any, options?: Options ) => void` can be used to set the `value` property
-    -   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property.
+    -   **setCategoryValue** `(categoryValue: string, options?: Options) => void`  can be used to set the `categoryValue` property.
     -   **`setSize`** `( size: number, options?: Options ) => void` can be used to set the `size` property
     -   **`setFrom`** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
     -   **setAfter** `(after: object, options?: Options) => void`

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -583,6 +583,7 @@ Returns the current mic instance. Can be used to set mic language and other prop
 The following methods can be used to set or update the properties in the search state:
 
 -   **setValue** `( value: any, options?: Options ) => void`  can be used to set the `value` property
+-   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property.
 -   **setSize** `( size: number, options?: Options ) => void`  can be used to set the `size` property
 -   **setFrom** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
 -   **setFuzziness** `( fuzziness: string|number, options?: Options ) => void` can be used to set the `fuzziness` property.

--- a/content/docs/reactivesearch/react-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/react-searchbox/searchcomponent.md
@@ -583,7 +583,7 @@ Returns the current mic instance. Can be used to set mic language and other prop
 The following methods can be used to set or update the properties in the search state:
 
 -   **setValue** `( value: any, options?: Options ) => void`  can be used to set the `value` property
--   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property.
+-   **setCategoryValue** `(categoryValue: string, options?: Options) => void`  can be used to set the `categoryValue` property.
 -   **setSize** `( size: number, options?: Options ) => void`  can be used to set the `size` property
 -   **setFrom** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
 -   **setFuzziness** `( fuzziness: string|number, options?: Options ) => void` can be used to set the `fuzziness` property.

--- a/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
+++ b/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
@@ -593,6 +593,8 @@ The following methods of `SearchComponent` class can be used to set or update th
     can be used to set the custom `results`
 -   **setValue** `(value: string, options?: Options) => void`
     can be used to set the `value` property
+-   **setCategoryValue** `(value: string, options?: Options) => void`
+    can be used to set the `categoryValue` property.
 
 -   **setReact** `(react: Object, options?: types.Options): void`
     can be used to set the `react` property
@@ -708,6 +710,7 @@ These are the properties that can be subscribed for the changes:
 -   `requestStatus`
 -   `error`
 -   `value`
+-   `categoryValue`
 -   `query`
 -   `micStatus`
 -   `dataField`

--- a/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
+++ b/content/docs/reactivesearch/searchbase/overview/searchcomponent.md
@@ -593,7 +593,7 @@ The following methods of `SearchComponent` class can be used to set or update th
     can be used to set the custom `results`
 -   **setValue** `(value: string, options?: Options) => void`
     can be used to set the `value` property
--   **setCategoryValue** `(value: string, options?: Options) => void`
+-   **setCategoryValue** `(categoryValue: string, options?: Options) => void`
     can be used to set the `categoryValue` property.
 
 -   **setReact** `(react: Object, options?: types.Options): void`

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -872,7 +872,7 @@ These are the properties that can be subscribed to:
     -   **`triggerCustomQuery`** `(options): Promise<any>` can be used to trigger the `defaultQuery` programmatically
     -   **`setDataField`** `( dataField: String | Array<String | DataField>, options?: Options ) => void`
     -   **`setValue`** `( value: any, options?: Options ) => void` can be used to set the `value` property
-    -   **setCategoryValue** `(value: string, options?: Options) => void` can be used to set the `categoryValue` property.
+    -   **setCategoryValue** `(categoryValue: string, options?: Options) => void` can be used to set the `categoryValue` property.
     -   **`setSize`** `( size: Number, options?: Options ) => void` can be used to set the `size` property
     -   **`setFrom`** `( from: Number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
     -   **`setFuzziness`** `( fuzziness: String|Number, options?: Options ) => void` can be used to set the `fuzziness` property.

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -872,6 +872,7 @@ These are the properties that can be subscribed to:
     -   **`triggerCustomQuery`** `(options): Promise<any>` can be used to trigger the `defaultQuery` programmatically
     -   **`setDataField`** `( dataField: String | Array<String | DataField>, options?: Options ) => void`
     -   **`setValue`** `( value: any, options?: Options ) => void` can be used to set the `value` property
+    -   **setCategoryValue** `(value: string, options?: Options) => void` can be used to set the `categoryValue` property.
     -   **`setSize`** `( size: Number, options?: Options ) => void` can be used to set the `size` property
     -   **`setFrom`** `( from: Number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
     -   **`setFuzziness`** `( fuzziness: String|Number, options?: Options ) => void` can be used to set the `fuzziness` property.

--- a/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
@@ -648,7 +648,7 @@ Returns the current mic instance. Can be used to set mic language and other prop
 The following methods can be used to set or update the properties in the search state:
 
 -   **setValue** `( value: any, options?: Options ) => void`  can be used to set the `value` property
--   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property.
+-   **setCategoryValue** `(categoryValue: string, options?: Options) => void`  can be used to set the `categoryValue` property.
 -   **setSize** `( size: number, options?: Options ) => void`  can be used to set the `size` property
 -   **setFrom** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
 -   **setAfter** `(after: object, options?: Options) => void`

--- a/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchcomponent.md
@@ -648,6 +648,7 @@ Returns the current mic instance. Can be used to set mic language and other prop
 The following methods can be used to set or update the properties in the search state:
 
 -   **setValue** `( value: any, options?: Options ) => void`  can be used to set the `value` property
+-   **setCategoryValue** `(value: string, options?: Options) => void`  can be used to set the `categoryValue` property.
 -   **setSize** `( size: number, options?: Options ) => void`  can be used to set the `size` property
 -   **setFrom** `( from: number, options?: Options ) => void` can be used to set the `from` property. Useful to implement pagination.
 -   **setAfter** `(after: object, options?: Options) => void`


### PR DESCRIPTION
**PR Type** `Enhancement`

**Description** The PR adds doc ref for `setCategoryValue` setter in `searchbase`, `react-searchbox`, `vue-searchbox`, and `react-native-searchbox` libs.

https://github.com/appbaseio/searchbox/pull/163