### PR TITLE
feat: add prop def for enterButton and renderEnterButton props

### DIFF
--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -689,6 +689,42 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
     ...
 />
 ```
+
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.
+
+    <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
+
+    ```jsx
+        <SearchBox            
+            id="search-component"
+            enterButton={true}
+        />
+    ```
+-   **renderEnterButton** `Function` [optional] renders a custom jsx markup for the enter button. Use in conjunction with `enterButton` prop set to `true`.
+
+    <img src="https://i.imgur.com/dRykMOg.png" style="margin:0 auto;display:block;"/>
+
+    ```jsx
+        <SearchBox
+            id="search-component"
+            enterButton
+            renderEnterButton={clickHandler => (
+                <div
+                    style={{
+                        height: '100%',
+                        display: 'flex',
+                        alignItems: 'stretch',
+                    }}
+                >
+                    <button style={{ border: '1px solid #c3c3c3' }} onClick={clickHandler}>
+                        🔍 Search
+                    </button>
+                </div>
+            )}
+        />
+    ```
+
+
 ### Customize style
 
 -   **innerClass** `Object` `SearchBox` component supports an `innerClass` prop to provide styles to the sub-components of `SearchBox`. These are the supported keys:

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -690,7 +690,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
 />
 ```
 
--   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`. You can also provide styles using the `enterButton` key in the `innerClass` prop.
 
     <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
 
@@ -734,6 +734,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
     -   `list`
     -   `recent-search-icon`
     -   `popular-search-icon`
+    -   `enterButton`
 
 -   **className** `String`
     CSS class to be injected on the component container.

--- a/content/docs/reactivesearch/react-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/react-searchbox/searchbox.md
@@ -690,7 +690,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
 />
 ```
 
--   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`. You can also provide styles using the `enterButton` key in the `innerClass` prop.
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`. You can also provide styles using the `enter-button` key in the `innerClass` prop.
 
     <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
 
@@ -734,7 +734,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
     -   `list`
     -   `recent-search-icon`
     -   `popular-search-icon`
-    -   `enterButton`
+    -   `enter-button`
 
 -   **className** `String`
     CSS class to be injected on the component container.

--- a/content/docs/reactivesearch/v3/search/searchbox.md
+++ b/content/docs/reactivesearch/v3/search/searchbox.md
@@ -589,7 +589,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 -   `list`
 -   `recent-search-icon`
 -   `popular-search-icon`
--   `enterButton`
+-   `enter-button`
 
 Read more about it [here](/docs/reactivesearch/v3/theming/classnameinjection/).
 
@@ -785,7 +785,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
 
 -   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
 
--   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`. You can also provide styles using the `enterButton` key in the `innerClass` prop.
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`. You can also provide styles using the `enter-button` key in the `innerClass` prop.
 
     <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
 

--- a/content/docs/reactivesearch/v3/search/searchbox.md
+++ b/content/docs/reactivesearch/v3/search/searchbox.md
@@ -784,6 +784,41 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
 
 -   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
 
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.
+
+    <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
+
+    ```jsx
+        <SearchBox            
+            id="search-component"
+            enterButton={true}
+        />
+    ```
+-   **renderEnterButton** `Function` [optional] renders a custom jsx markup for the enter button. Use in conjunction with `enterButton` prop set to `true`.
+
+    <img src="https://i.imgur.com/dRykMOg.png" style="margin:0 auto;display:block;"/>
+
+    ```jsx
+        <SearchBox
+            id="search-component"
+            enterButton
+            renderEnterButton={clickHandler => (
+                <div
+                    style={{
+                        height: '100%',
+                        display: 'flex',
+                        alignItems: 'stretch',
+                    }}
+                >
+                    <button style={{ border: '1px solid #c3c3c3' }} onClick={clickHandler}>
+                        🔍 Search
+                    </button>
+                </div>
+            )}
+        />
+    ```
+
+
 ## Examples
 
 <a href="https://opensource.appbase.io/playground/?selectedKind=Search%20components%2FSearchBox" target="_blank">SearchBox with default props</a>

--- a/content/docs/reactivesearch/v3/search/searchbox.md
+++ b/content/docs/reactivesearch/v3/search/searchbox.md
@@ -589,6 +589,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 -   `list`
 -   `recent-search-icon`
 -   `popular-search-icon`
+-   `enterButton`
 
 Read more about it [here](/docs/reactivesearch/v3/theming/classnameinjection/).
 
@@ -784,7 +785,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
 
 -   **isOpen** `boolean` [optional] When set to `true` the dropdown is displayed on the initial render. Defaults to `false`.
 
--   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`. You can also provide styles using the `enterButton` key in the `innerClass` prop.
 
     <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
 

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -461,7 +461,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
  </search-box>
 ```
 
--   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.  You can also provide styles using the `enterButton` key in the `innerClass` prop.
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.  You can also provide styles using the `enter-button` key in the `innerClass` prop.
 
     <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
 
@@ -480,7 +480,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
     -   `title`
     -   `input`
     -   `list`
-    -   `enterButton`
+    -   `enter-button`
 
 -   **className** `String`
     CSS class to be injected on the component container.

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -986,10 +986,7 @@ You can use a custom icon in place of the default icon for the popular searches 
 ```jsx
 <search-box
       ...
-      :enablePopularSuggestions="true"
-      :innerClass="{
-         'popular-search-icon': '...'
-      }"
+      :enterButton="true"
 >
     <div
         slot="renderEnterButton"

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -461,6 +461,18 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
  </search-box>
 ```
 
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.
+
+    <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
+
+```jsx
+ <search-box
+    :enterButton="true"        
+  >
+  // ... other slots
+ </search-box>
+```   
+
 ### Customize style
 
 -   **innerClass** `Object` `SearchBox` component supports an `innerClass` prop to provide styles to the sub-components of `SearchBox`. These are the supported keys:
@@ -965,5 +977,31 @@ You can use a custom icon in place of the default icon for the popular searches 
         src="https://img.icons8.com/cute-clipart/64/000000/search.png"
         height="30px"
       />
+</search-box>
+```
+
+-   **renderEnterButton** `slot-scope` [optional] The custom HTML markup displayed for enterButton. Use in conjunction with `enterButton` prop set to `true`.
+<img src="https://i.imgur.com/dRykMOg.png" style="margin:0 auto;display:block;"/>
+
+```jsx
+<search-box
+      ...
+      :enablePopularSuggestions="true"
+      :innerClass="{
+         'popular-search-icon': '...'
+      }"
+>
+    <div
+        slot="renderEnterButton"
+        slot-scope="onClick"
+        :style="{ height: '100%', display: 'flex', alignItems: 'stretch' }"
+    >
+        <button
+            :style="{ border: '1px solid #c3c3c3', cursor       'pointer' }"
+            v-on:click="onClick"
+        >
+            🔍 Search
+        </button>
+    </div>
 </search-box>
 ```

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -994,7 +994,7 @@ You can use a custom icon in place of the default icon for the popular searches 
         :style="{ height: '100%', display: 'flex', alignItems: 'stretch' }"
     >
         <button
-            :style="{ border: '1px solid #c3c3c3', cursor       'pointer' }"
+            :style="{ border: '1px solid #c3c3c3', cursor: 'pointer' }"
             v-on:click="onClick"
         >
             🔍 Search

--- a/content/docs/reactivesearch/vue-searchbox/searchbox.md
+++ b/content/docs/reactivesearch/vue-searchbox/searchbox.md
@@ -461,7 +461,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
  </search-box>
 ```
 
--   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.
+-   **enterButton** `boolean` [optional] When set to `true`, the results would only be updated on press of the  button. Defaults to `false`.  You can also provide styles using the `enterButton` key in the `innerClass` prop.
 
     <img src="https://i.imgur.com/8ZoA42b.png" style="margin:0 auto;display:block;"/>
 
@@ -480,6 +480,7 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
     -   `title`
     -   `input`
     -   `list`
+    -   `enterButton`
 
 -   **className** `String`
     CSS class to be injected on the component container.


### PR DESCRIPTION
**PR Type** `Feature` 🌟 

**Description** The PR adds prop def(s) for newly added `enterButton` and `renderEnterButton` props for reactivesearch(web & vue) and SearchBox (react & vue) libs.

**Libs**

- [x] Reactivesearch web
- [x] Reactivesearch Vue 👉 https://github.com/appbaseio/Docs/pull/265/commits/38aa1b7aab75c3ecc4622a1352ce9718a3e784bd
- [x] React-SearchBox
- [x] Vue -SearchBox

**Related PR(s)**

- https://github.com/appbaseio/reactivesearch/pull/1936
- https://github.com/appbaseio/searchbox/pull/186