### PR TITLE
feat(web-vue): add prop def enableDefaultSuggestions prop to DataSearch

### DIFF
--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -160,6 +160,8 @@ Example uses:
     defaults to `false`. When set to `true` the component will only set its value and fire the query if the value was selected from the suggestion. Otherwise the value will be cleared on selection. This is only relevant with `autosuggest`.
 -   **defaultSuggestions** `Array` [optional]
     preset search suggestions to be shown on focus when the search box does not have any search query text set. Accepts an array of objects each having a **label** and **value** property. The label can contain either String or an HTML element.
+-   **enableDefaultSuggestions** `bool` [optional]
+    Defaults to `true`. When set to `false`, initial suggestions(including recent, popular, index, or defaultSuggestions) are not displayed when the query value is empty.     
 -   **debounce** `Number` [optional]
     set the milliseconds to wait before executing the query. Defaults to `0`, i.e. no debounce.
 -   **highlight** `Boolean` [optional]

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -69,6 +69,11 @@ Example uses:
     and: ['CategoryFilter', 'SearchFilter']
   }"
 	:URLParams="false"
+  :defaultSuggestions="[
+		{ label: 'Songwriting', value: 'Songwriting' },
+		{ label: 'Musicians', value: 'Musicians' },
+	]"
+  :enableDefaultSuggestions="true"
 />
 ```
 
@@ -199,6 +204,12 @@ Example uses:
 
 `Note:` Check the above concept in action over [here](https://codesandbox.io/s/musing-allen-qc58z).
 
+-   **defaultSuggestions** `Array` [optional]
+    preset search suggestions to be shown on focus when the search box does not have any search query text set. Accepts an array of objects each having a **label** and **value** property.
+
+-   **enableDefaultSuggestions** `bool` [optional]
+    Defaults to `true`. When set to `false`, initial suggestions(including recent, popular, index, or defaultSuggestions) are not displayed when the query value is empty.    
+    
 - **filterLabel** `String` [optional]
   An optional label to display for the component in the global selected filters view. This is only applicable if `showFilter` is enabled. Default value used here is `componentId`.
 - **clearIcon** `JSX` [optional]


### PR DESCRIPTION
**PR Type** `enhancement` 🏗️ 

**Description** The PR adds prop def(s) for `enableDefaultSuggestions` prop added to `<DataSearch />` components in web & vue libs.

[📔  Notion](https://www.notion.so/appbase/defaultSuggestions-behavior-for-DataSearch-fc5dcb3dd55a42d184d8815b0594bb44)

https://github.com/appbaseio/reactivesearch/pull/1967