### PR TITLE
feat(vue): prop def for multi-select support for DataSearch & SearchBox

### DIFF
--- a/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
+++ b/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
@@ -119,5 +119,5 @@ Read more about it [here](/docs/reactivesearch/vue/theming/ClassnameInjection/).
         function to clear a selected filter's value. It takes the `componentId` as a param.
     - **`setValue`**: `Function - (String, Any) => void` 
         function to set a component's value. It takes the `componentId` and `value`(to set) as parameters.
-    - **resetValuesToDefault**: `Function`
-        function to reset values of the selected filters to their default values. It accepts an Array of componenIds to avoid resetting their values.
+    - **`resetValuesToDefault`**: `Function - (Array<String>) => void`
+        function to reset values of the selected filters to their default values. It accepts an Array of componentIds to avoid resetting their values.

--- a/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
+++ b/content/docs/reactivesearch/vue/advanced/SelectedFilters.md
@@ -107,3 +107,17 @@ Read more about it [here](/docs/reactivesearch/vue/theming/ClassnameInjection/).
     CSS class to be injected on the component container.
 -   **slot-scope** ( Default Slot )
     Enables custom rendering for **SelectedFilters** component. It provides an object as a param which contains all the props needed to render the custom selected-filters, including the functions to clear and update the component values. You can find the example at [here](https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/vue/examples/selected-filters-custom).
+
+    It accepts an object with these properties:
+    - **`components`**: `Array<String>`
+        array of `componentId`s which have got `showFilter` set to `true`.
+    - **`selectedValues`**: `Object`
+        map of components' Ids and their updated values.
+    - **`clearValues`**: `Function - () => void` 
+        function to clear all selected filters.
+    - **`clearValue`**: `Function - (String) => void` 
+        function to clear a selected filter's value. It takes the `componentId` as a param.
+    - **`setValue`**: `Function - (String, Any) => void` 
+        function to set a component's value. It takes the `componentId` and `value`(to set) as parameters.
+    - **resetValuesToDefault**: `Function`
+        function to reset values of the selected filters to their default values. It accepts an Array of componenIds to avoid resetting their values.

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -41,6 +41,7 @@ Example uses:
 	highlightField="group_city"
 	queryFormat="or"
 	filterLabel="City"
+  :mode="tag"
 	:autosuggest="true"
 	:highlight="true"
 	:showFilter="true"
@@ -81,6 +82,22 @@ Example uses:
 
 -   **componentId** `String`
     unique identifier of the component, can be referenced in other components' `react` prop.
+-   **mode** `String`
+    DataSearch component offers two modes of usage, `select` & `tag`. When mode is set to `tag` DataSearch allows selecting multiple suggestions. Defaults to `select`.
+
+    ```html
+    <template>
+	    <data-search
+        componentId="title"
+        highlight="true"
+        :dataField="['title', 'text']"
+        :mode="tag"
+      />
+    </template>
+    ```
+
+    <img src="https://i.imgur.com/DVhSiGV.png" alt="DataSearch tag mode" />
+
 -   **dataField** `string | Array<string | DataField*>` [optional*]
     index field(s) to be connected to the component’s UI view. DataSearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
     Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
@@ -154,8 +171,11 @@ Example uses:
     set the title of the component to be shown in the UI.
 -   **defaultValue** `string` [optional]
     preset the search query text in the search box.
--   **value** `string` [optional]
+-   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `change` event.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
+    
 -   **fieldWeights** `Array` [optional]
     set the search weight for the database fields, useful when dataField is an Array of more than one field. This prop accepts an array of numbers. A higher number implies a higher relevance weight for the corresponding field in the search results.
 -   **placeholder** `String` [optional]
@@ -607,6 +627,30 @@ You can use `DataSearch` with `renderQuerySuggestions slot` as shown:
 
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
 
+- **renderSelectedTags** `slot-scope` [optional] to custom render tags when mode is set to `tag`.
+  <img src="https://i.imgur.com/BzHc1tn.png" height="75px" style="margin:0 auto;display:block;"/>
+
+```jsx
+  <data-search
+      ...
+      :mode="tag"
+      :innerClass="{
+         'selected-tag': '...'
+      }"
+  >
+		<div slot="renderSelectedTags" slot-scope="{ values, handleClear, handleClearAll }">
+			<button
+				style="{ background-color: highlightedIndex ? 'grey' : 'transparent'color: 'green' }"
+				v-for="tagValue in values"
+				:key="tagValue"
+				@click="() => handleClear(tagValue)"
+			>
+				{{ tagValue }}
+			</button>
+		</div>
+  </data-search>
+```
+
 ## Demo
 
 <br />
@@ -621,6 +665,7 @@ You can use `DataSearch` with `renderQuerySuggestions slot` as shown:
 - `input`
 - `recent-search-icon`
 - `popular-search-icon`
+- `selected-tag`
 
 Read more about it [here](/docs/reactivesearch/vue/theming/ClassnameInjection/).
 

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -41,7 +41,7 @@ Example uses:
 	highlightField="group_city"
 	queryFormat="or"
 	filterLabel="City"
-  :mode="tag"
+    :mode="tag"
 	:autosuggest="true"
 	:highlight="true"
 	:showFilter="true"
@@ -627,8 +627,7 @@ You can use `DataSearch` with `renderQuerySuggestions slot` as shown:
 
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
 
-- **renderSelectedTags** `slot-scope` [optional] to custom render tags when mode is set to `tag`.
-Provides 
+- **renderSelectedTags** `slot-scope` [optional] custom render tags when mode is set to `tag`.
 It accepts an object with these properties:
   - **`values`**: `Array<String>`
     array of selected values.

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -175,7 +175,7 @@ Example uses:
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `change` event.
 
     > Data type is Array<String> when `mode` prop is set to `tag`.
-    
+
 -   **fieldWeights** `Array` [optional]
     set the search weight for the database fields, useful when dataField is an Array of more than one field. This prop accepts an array of numbers. A higher number implies a higher relevance weight for the corresponding field in the search results.
 -   **placeholder** `String` [optional]
@@ -628,7 +628,14 @@ You can use `DataSearch` with `renderQuerySuggestions slot` as shown:
     > Note: This only works when `enableAppbase` prop is set to true in `ReactiveBase`.
 
 - **renderSelectedTags** `slot-scope` [optional] to custom render tags when mode is set to `tag`.
-  <img src="https://i.imgur.com/BzHc1tn.png" height="75px" style="margin:0 auto;display:block;"/>
+Provides 
+It accepts an object with these properties:
+  - **`values`**: `Array<String>`
+    array of selected values.
+  - **`handleClear`**: `Function - (string) => void`
+    function to clear a tag value. It accepts the tag value(String) as a parameter.
+  - **`handleClearAll`**: `Function - () => void` 
+    function to clear all selected values.
 
 ```jsx
   <data-search

--- a/content/docs/reactivesearch/vue/search/SearchBox.md
+++ b/content/docs/reactivesearch/vue/search/SearchBox.md
@@ -36,6 +36,7 @@ Example uses:
 ```html
 <search-box
 	componentId="SearchSensor"
+  :mode="tag"
 	title="Search"
 	defaultValue="Songwriting"
 	placeholder="Search for cities or venues"
@@ -118,6 +119,22 @@ Example uses:
 
 -   **componentId** `String`
     unique identifier of the component, can be referenced in other components' `react` prop.
+-   **mode** `String`
+    SearchBox component offers two modes of usage, `select` & `tag`. When mode is set to `tag` SearchBox allows selecting multiple suggestions. Defaults to `select`.
+
+    ```html
+    <template>
+	    <search-box
+        componentId="title"
+        highlight="true"
+        :dataField="['title', 'text']"
+        :mode="tag"
+      />
+    </template>
+    ```
+
+    <img src="https://i.imgur.com/DVhSiGV.png" alt="SearchBox tag mode" />
+
 -   **dataField** `string | Array<string | DataField*>` [optional*]
     index field(s) to be connected to the component’s UI view. SearchBox accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
     Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
@@ -234,8 +251,11 @@ Example uses:
     set the title of the component to be shown in the UI.
 -   **defaultValue** `string` [optional]
     preset the search query text in the search box.
--   **value** `string` [optional]
+-   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `change` event.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
+
 -   **fieldWeights** `Array` [optional]
     set the search weight for the database fields, useful when dataField is an Array of more than one field. This prop accepts an array of numbers. A higher number implies a higher relevance weight for the corresponding field in the search results.
 -   **placeholder** `String` [optional]
@@ -339,7 +359,7 @@ Example uses:
   >
       <img slot="addonBefore" src="..." />
       <img slot="addonAfter" src="..." />
-  </data-sesarch>
+  </search-box>
 ```
 
 - **queryFormat** `String` [optional]
@@ -667,6 +687,38 @@ Or you can also use render as prop.
 </search-box>
 ```
 
+- **renderSelectedTags** `slot-scope` [optional] to custom render tags when mode is set to `tag`.
+Provides 
+It accepts an object with these properties:
+  - **`values`**: `Array<String>`
+    array of selected values.
+  - **`handleClear`**: `Function - (string) => void`
+    function to clear a tag value. It accepts the tag value(String) as a parameter.
+  - **`handleClearAll`**: `Function - () => void` 
+    function to clear all selected values.
+
+```jsx
+  <search-box
+      ...
+      :mode="tag"
+      :innerClass="{
+         'selected-tag': '...'
+      }"
+  >
+		<div slot="renderSelectedTags" slot-scope="{ values, handleClear, handleClearAll }">
+			<button
+				style="{ background-color: highlightedIndex ? 'grey' : 'transparent'color: 'green' }"
+				v-for="tagValue in values"
+				:key="tagValue"
+				@click="() => handleClear(tagValue)"
+			>
+				{{ tagValue }}
+			</button>
+		</div>
+  </search-box>
+```
+
+
 ## Demo
 
 <br />
@@ -682,6 +734,7 @@ Or you can also use render as prop.
 - `recent-search-icon`
 - `popular-search-icon`
 - `enter-button`
+- `selected-tag`
 
 Read more about it [here](/docs/reactivesearch/vue/theming/ClassnameInjection/).
 

--- a/content/docs/reactivesearch/vue/search/SearchBox.md
+++ b/content/docs/reactivesearch/vue/search/SearchBox.md
@@ -36,7 +36,7 @@ Example uses:
 ```html
 <search-box
 	componentId="SearchSensor"
-  :mode="tag"
+    :mode="tag"
 	title="Search"
 	defaultValue="Songwriting"
 	placeholder="Search for cities or venues"


### PR DESCRIPTION
**PR Type** `Feature` ⭐ 

**Description** The PR adds prop defs for multiple selections in search types of components(DataSearch and SearchBox).

[📔  Notion](https://www.notion.so/appbase/SearchBox-DataSearch-Add-support-for-multiple-suggestions-selection-e55b7aa2abc3496da57a63125f49c24e)

**Related PR(s)**
- https://github.com/appbaseio/reactivesearch/pull/2023
- https://github.com/appbaseio/reactivecore/pull/129
- https://github.com/appbaseio/vue-playground/pull/55