### PR TITLE
feat: add doc ref for Saved search support in StateProvider

### DIFF
--- a/content/docs/reactivesearch/v3/advanced/stateprovider.md
+++ b/content/docs/reactivesearch/v3/advanced/stateprovider.md
@@ -110,7 +110,7 @@ For example:
 ```
 **Example**
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/web/examples/SavedSearchSupport?fontsize=14&hidenavigation=1&theme=dark"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/web/examples/SavedSearch?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="saved-search"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/v3/advanced/stateprovider.md
+++ b/content/docs/reactivesearch/v3/advanced/stateprovider.md
@@ -76,6 +76,39 @@ For example:
  }
 ```
 
+**`setSearchState`**: `Function`<br/>
+
+`setSearchState()` is a function which can be used to set custom search state of the app, takes one argument which is a custom state object.
+
+```js
+<StateProvider>
+	{({ setSearchState }) => (
+		<button
+			onClick={() => {
+				setSearchState(customSearchState);
+			}}
+		>
+			Set Search State
+		</button>
+	)}
+</StateProvider>
+```
+
+`customSearchState` is an object with component id as key and component's value as value.<br/>
+
+For example:
+
+```js
+ {
+  	BooksSearch: 'A song of Ice and Fire',
+  	RatingsFilter:  {
+            start: 4,
+            end: 5,
+            label: "★★★★ & up"
+	}
+ }
+```
+
 -   **includeKeys** `string[]` [optional]
     defaults set to `['value', 'hits', 'aggregations', 'error']` which means that by default your search state for a particular component will only contains these keys. Although the default search state fulfills most of your common use cases but you can also control it by defining your custom keys with the help of `includeKeys` prop.<br/><br/>
     For example:

--- a/content/docs/reactivesearch/v3/advanced/stateprovider.md
+++ b/content/docs/reactivesearch/v3/advanced/stateprovider.md
@@ -108,6 +108,15 @@ For example:
 	}
  }
 ```
+**Example**
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/web/examples/SavedSearchSupport?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="saved-search"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+   
 
 -   **includeKeys** `string[]` [optional]
     defaults set to `['value', 'hits', 'aggregations', 'error']` which means that by default your search state for a particular component will only contains these keys. Although the default search state fulfills most of your common use cases but you can also control it by defining your custom keys with the help of `includeKeys` prop.<br/><br/>

--- a/content/docs/reactivesearch/vue/advanced/StateProvider.md
+++ b/content/docs/reactivesearch/vue/advanced/StateProvider.md
@@ -92,7 +92,7 @@ For example:
 
 #### Example
 
-<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/vue/examples/saved-search-support?fontsize=14&hidenavigation=1&theme=dark"
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/vue/examples/saved-search?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="saved-search-support"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/content/docs/reactivesearch/vue/advanced/StateProvider.md
+++ b/content/docs/reactivesearch/vue/advanced/StateProvider.md
@@ -90,6 +90,15 @@ For example:
  }
 ```
 
+#### Example
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/vue/examples/saved-search-support?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="saved-search-support"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
 ### Props
 
 -   **componentIds** `string|string[]` [optional]

--- a/content/docs/reactivesearch/vue/advanced/StateProvider.md
+++ b/content/docs/reactivesearch/vue/advanced/StateProvider.md
@@ -48,6 +48,48 @@ For example:
  }
 ```
 
+### Setting custom state
+
+`setSearchState()` is a function which can be used to set custom search state of the app, takes one argument which is a custom state object.
+
+```html
+<template>
+    <state-provider>
+        <div slot-scope="{ setSearchState }">
+           <button @click="() => setSearchState(this.searchState)">Replay Search</button>
+        </div>
+    </state-provider>
+</template>
+<script>
+export default {
+	data() {
+	    return {
+	        searchState: { 
+                // custom state
+                // [componentId]: component_value
+                'result': null,
+                'search': 'Netherlands'
+        }
+    }
+  }
+}
+</script>
+```
+
+Custom state is an object with component id as key and component's value as value.<br/>
+For example:
+
+```js
+ {
+  	BooksSearch: 'A song of Ice and Fire',
+  	RatingsFilter:  {
+            start: 4,
+            end: 5,
+            label: "★★★★ & up"
+	}
+ }
+```
+
 ### Props
 
 -   **componentIds** `string|string[]` [optional]


### PR DESCRIPTION
**PR Type** `Feature`

**Description** The PR adds doc ref for Saved search support added in StateProvider component (`React` and `Vue`).

[📔  Notion](https://www.notion.so/appbase/ReactiveSearch-Saved-Search-support-8d65d3b84c27499a9e23e983b364082d)

https://github.com/appbaseio/reactivesearch/pull/2039