### PR TITLE
feat(web): prop def for multi-select support for DataSearch & SearchBox 

### DIFF
--- a/content/docs/reactivesearch/v3/advanced/selectedfilters.md
+++ b/content/docs/reactivesearch/v3/advanced/selectedfilters.md
@@ -124,6 +124,20 @@ Read more about it [here](/docs/reactivesearch/v3/theming/classnameinjection/).
 -   **render** `Function`
     Enables custom rendering for **SelectedFilters** component. It provides an object as a param which contains all the props needed to render the custom selected-filters, including the functions to clear and update the component values. [Check the usage here](https://github.com/appbaseio/reactivesearch/blob/dev/packages/web/examples/CustomSelectedFilters/src/index.js).
 
+    It accepts an object with these properties:
+    - **`components`**: `Array<String>`
+        array of `componentId`s which have got `showFilter` set to `true`.
+    - **`selectedValues`**: `Object`
+        map of components' Ids and their updated values.
+    - **`clearValues`**: `Function - () => void` 
+        function to clear all selected filters.
+    - **`clearValue`**: `Function - (String) => void` 
+        function to clear a selected filter's value. It takes the `componentId` as a param.
+    - **`setValue`**: `Function - (String, Any) => void` 
+        function to set a component's value. It takes the `componentId` and `value`(to set) as parameters.
+    - **`resetValuesToDefault`**: `Function - (Array<String>) => void`
+        function to reset values of the selected filters to their default values. It accepts an Array of componentIds to avoid resetting their values.
+        
 ### Examples
 
 SelectedFilters work with most ReactiveSearch components. See more stories for SelectedFilters with a SingleList on playground.

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -126,8 +126,11 @@ Example uses:
     Set the path of the `nested` type under which the `dataField` is present. Only applicable only when the field(s) specified in the `dataField` is(are) present under a [`nested` type](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html) mapping.
 -   **title** `String or JSX` [optional]
     set the title of the component to be shown in the UI.
--   **defaultValue** `string` [optional]
+-   **defaultValue** `String` | `Array<String>` [optional]
     set the initial search query text on mount.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
+    
 -   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `onChange` prop.
 

--- a/content/docs/reactivesearch/v3/search/datasearch.md
+++ b/content/docs/reactivesearch/v3/search/datasearch.md
@@ -43,6 +43,7 @@ Example uses:
 			"weight": 3
 		}
 	]}
+    mode="tag" // accepts either of 'select' or 'tag' defaults to 'select'    
 	title="Search"
 	defaultValue="Songwriting"
 	placeholder="Search for cities or venues"
@@ -70,6 +71,17 @@ Example uses:
 
 -   **componentId** `String`
     unique identifier of the component, can be referenced in other components' `react` prop.
+-   **mode** `String`
+    DataSearch component offers two modes of usage, `select` & `tag`. When mode is set to `tag` DataSearch allows selecting multiple suggestions. Defaults to `select`.
+    
+    ```jsx
+    <DataSearch
+        componentId="searchSensor"
+        // ... other props
+        mode="tag"
+    />
+    ```    
+
 -   **dataField** `string | Array<string | DataField*>` [optional*]
     index field(s) to be connected to the component’s UI view. DataSearch accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
     Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
@@ -116,8 +128,11 @@ Example uses:
     set the title of the component to be shown in the UI.
 -   **defaultValue** `string` [optional]
     set the initial search query text on mount.
--   **value** `string` [optional]
+-   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `onChange` prop.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
+
 -   **enableSynonyms** `bool` [optional]
     Defaults to `true`, can be used to `disable/enable` the synonyms behavior for the search query. Read more about it [here](/docs/search/reactivesearch-api/reference/#enablesynonyms)
     > Note:
@@ -523,6 +538,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 -   `list`
 -   `recent-search-icon`
 -   `popular-search-icon`
+-   `selected-tag`
 
 Read more about it [here](/docs/reactivesearch/v3/theming/classnameinjection/).
 
@@ -731,6 +747,31 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
         ...
  />
 ```
+
+-   **renderSelectedTags** `Function` [optional] to custom render tags when mode is set to `tag`.
+
+Function param accepts an object with the following properties:
+  - **`values`**: `Array<String>`
+    array of selected values.
+  - **`handleClear`**: `Function - (string) => void`
+    function to clear a tag value. It accepts the tag value(String) as a parameter.
+
+  - **`handleClearAll`**: `Function - () => void` 
+    function to clear all selected values.
+
+    ```jsx
+        <DataSearch
+            id="search-component"
+            enterButton
+            renderSelectedTags=({ 
+                values = [], 
+                handleClear, 
+                handleClearAll }) => {
+                // return custom rendered tags 
+            }
+        />
+    ```
+
 
 ## Examples
 

--- a/content/docs/reactivesearch/v3/search/searchbox.md
+++ b/content/docs/reactivesearch/v3/search/searchbox.md
@@ -153,8 +153,11 @@ Example uses:
     Set the path of the `nested` type under which the `dataField` is present. Only applicable only when the field(s) specified in the `dataField` is(are) present under a [`nested` type](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html) mapping.
 -   **title** `String or JSX` [optional]
     set the title of the component to be shown in the UI.
--   **defaultValue** `string` [optional]
+-   **defaultValue** `String` | `Array<String>` [optional]
     set the initial search query text on mount.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
+    
 -   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `onChange` prop.
 

--- a/content/docs/reactivesearch/v3/search/searchbox.md
+++ b/content/docs/reactivesearch/v3/search/searchbox.md
@@ -46,6 +46,7 @@ Example uses:
             }
         ]}
         title="Search"
+        mode="tag" // accepts either of 'select' or 'tag', defaults to 'select'
         defaultValue="Songwriting"
         placeholder="Search for cities or venues"
         autosuggest={true}
@@ -97,6 +98,17 @@ Example uses:
 
 -   **componentId** `String`
     unique identifier of the component, can be referenced in other components' `react` prop.
+-   **mode** `String`
+    SearchBox component offers two modes of usage, `select` & `tag`. When mode is set to `tag` SearchBox allows selecting multiple suggestions. Defaults to `select`.
+    
+    ```jsx
+    <SearchBox
+        componentId="searchSensor"
+        // ... other props
+        mode="tag"
+    />
+    ```    
+
 -   **dataField** `string | Array<string | DataField*>` [optional*]
     index field(s) to be connected to the component’s UI view. SearchBox accepts an `Array` in addition to `string`, which is useful for searching across multiple fields with or without field weights.<br/>
     Field weights allow weighted search for the index fields. A higher number implies a higher relevance weight for the corresponding field in the search results.<br/>
@@ -143,8 +155,11 @@ Example uses:
     set the title of the component to be shown in the UI.
 -   **defaultValue** `string` [optional]
     set the initial search query text on mount.
--   **value** `string` [optional]
+-   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `onChange` prop.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
+
 -   **enableSynonyms** `bool` [optional]
     Defaults to `true`, can be used to `disable/enable` the synonyms behavior for the search query. Read more about it [here](/docs/search/reactivesearch-api/reference/#enablesynonyms)
     > Note:
@@ -642,6 +657,7 @@ This prop allows specifying additional options to the `distinctField` prop. Usin
 -   `active-suggestion-item`
 -   `suggestion-item`
 -   `enter-button`
+-   `selected-tag`
 
 Read more about it [here](/docs/reactivesearch/v3/theming/classnameinjection/).
 
@@ -868,6 +884,30 @@ A list of keyboard shortcuts that focus the search box. Accepts key names and ke
                     </button>
                 </div>
             )}
+        />
+    ```
+
+-   **renderSelectedTags** `Function` [optional] to custom render tags when mode is set to `tag`.
+
+Function param accepts an object with the following properties:
+  - **`values`**: `Array<String>`
+    array of selected values.
+  - **`handleClear`**: `Function - (string) => void`
+    function to clear a tag value. It accepts the tag value(String) as a parameter.
+
+  - **`handleClearAll`**: `Function - () => void` 
+    function to clear all selected values.
+
+    ```jsx
+        <SearchBox
+            id="search-component"
+            enterButton
+            renderSelectedTags=({ 
+                values = [], 
+                handleClear, 
+                handleClearAll }) => {
+                // return custom rendered tags 
+            }
         />
     ```
 

--- a/content/docs/reactivesearch/vue/search/DataSearch.md
+++ b/content/docs/reactivesearch/vue/search/DataSearch.md
@@ -169,8 +169,10 @@ Example uses:
     Set the path of the `nested` type under which the `dataField` is present. Only applicable only when the field(s) specified in the `dataField` is(are) present under a [`nested` type](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html) mapping.
 -   **title** `String or JSX` [optional]
     set the title of the component to be shown in the UI.
--   **defaultValue** `string` [optional]
+-   **defaultValue** `String` | `Array<String>` [optional]
     preset the search query text in the search box.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
 -   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `change` event.
 

--- a/content/docs/reactivesearch/vue/search/SearchBox.md
+++ b/content/docs/reactivesearch/vue/search/SearchBox.md
@@ -249,8 +249,10 @@ Example uses:
     Set the path of the `nested` type under which the `dataField` is present. Only applicable only when the field(s) specified in the `dataField` is(are) present under a [`nested` type](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html) mapping.
 -   **title** `String or JSX` [optional]
     set the title of the component to be shown in the UI.
--   **defaultValue** `string` [optional]
+-   **defaultValue** `String` | `Array<String>` [optional]
     preset the search query text in the search box.
+
+    > Data type is Array<String> when `mode` prop is set to `tag`.
 -   **value** `String` | `Array<String>` [optional]
     sets the current value of the component. It sets the search query text (on mount and on update). Use this prop in conjunction with the `change` event.
 


### PR DESCRIPTION
**PR Type** `Feature` ⭐ 

**Description** The PR adds prop defs for multiple selections in search types of components(DataSearch and SearchBox).

[📔  Notion](https://www.notion.so/appbase/SearchBox-DataSearch-Add-support-for-multiple-suggestions-selection-e55b7aa2abc3496da57a63125f49c24e)

**Related PR(s)**
- https://github.com/appbaseio/reactivesearch/pull/2051
- https://github.com/appbaseio/playground/pull/101