### PR TITLE
Docs/use analytics library

### DIFF
--- a/content/docs/reactivesearch/v3/advanced/analytics.md
+++ b/content/docs/reactivesearch/v3/advanced/analytics.md
@@ -169,6 +169,43 @@ For an example,
 </ReactiveList>
 ```
 
+## Configure with **useAnalytics** hook
+
+We can import `useAnalytics` hook directly from the **@appbaseio/reactivesearch** package. When used, it returns an instance of the [analytics library](https://github.com/appbaseio/analytics.js). It uses the **url** and **credentials** provided to the parent `ReactiveBase` component.
+
+For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. Note`queryID` is required property and we can populate automatically by calling a method on the same instance.
+
+```jsx
+import { useAnalytics } from '@appbaseio/reactivesearch'
+
+const VisitStoreButton = () => {
+	const aaInstance = useAnalytics();
+	const handleVisitStore = () => {
+		aaInstance.conversion({
+			queryID: aaInstance.getQueryID(),
+			objects: ['Harry Potter', 'Frankenstein'],
+		});
+	};
+	return (
+		<button
+			onClick={handleVisitStore}
+		>
+			Visit Store
+		</button>
+	);
+};
+```
+
+You can also view the complete demo as a codesanbox example below. 
+
+<iframe src="https://codesandbox.io/embed/github/appbasio/reactivesearch/tree/next/packages/web/examples/AnalyticsWithHook?fontsize=14&hidenavigation=1&theme=dark"
+     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="analytics-with-hook"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
+
+
 ## Configure the analytics experience
 You can define the `appbaseConfig` prop in the `ReactiveBase` component to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:
 ### recordAnalytics

--- a/content/docs/reactivesearch/v3/advanced/analytics.md
+++ b/content/docs/reactivesearch/v3/advanced/analytics.md
@@ -173,7 +173,7 @@ For an example,
 
 We can import `useAnalytics` hook directly from the **@appbaseio/reactivesearch** library. When used, it returns an instance of the [analytics library](https://github.com/appbaseio/analytics.js) which uses the **url** and **credentials** provided to the parent `ReactiveBase` component.
 
-For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. Note `queryID` is required property and we can populate it automatically by calling a method on the same instance.
+For example, if we want to track conversions when a user clicks on **"Visit Store"** button then we can build a button as shown in snippet below. Note `queryID` is required property and we can populate it automatically by calling a method on the same instance.
 
 ```jsx
 import { useAnalytics } from '@appbaseio/reactivesearch'

--- a/content/docs/reactivesearch/v3/advanced/analytics.md
+++ b/content/docs/reactivesearch/v3/advanced/analytics.md
@@ -196,7 +196,7 @@ const VisitStoreButton = () => {
 };
 ```
 
-You can also view the complete demo as a codesanbox example below. 
+You can also view the complete demo as a codesandbox example below. 
 
 <iframe src="https://codesandbox.io/embed/github/appbasio/reactivesearch/tree/next/packages/web/examples/AnalyticsWithHook?fontsize=14&hidenavigation=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"

--- a/content/docs/reactivesearch/v3/advanced/analytics.md
+++ b/content/docs/reactivesearch/v3/advanced/analytics.md
@@ -171,7 +171,7 @@ For an example,
 
 ## Configure with **useAnalytics** hook
 
-We can import `useAnalytics` hook directly from the **@appbaseio/reactivesearch** package. When used, it returns an instance of the [analytics library](https://github.com/appbaseio/analytics.js). It uses the **url** and **credentials** provided to the parent `ReactiveBase` component.
+We can import `useAnalytics` hook directly from the **@appbaseio/reactivesearch** library. When used, it returns an instance of the [analytics library](https://github.com/appbaseio/analytics.js) which uses the **url** and **credentials** provided to the parent `ReactiveBase` component.
 
 For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. Note `queryID` is required property and we can populate it automatically by calling a method on the same instance.
 

--- a/content/docs/reactivesearch/v3/advanced/analytics.md
+++ b/content/docs/reactivesearch/v3/advanced/analytics.md
@@ -173,7 +173,7 @@ For an example,
 
 We can import `useAnalytics` hook directly from the **@appbaseio/reactivesearch** package. When used, it returns an instance of the [analytics library](https://github.com/appbaseio/analytics.js). It uses the **url** and **credentials** provided to the parent `ReactiveBase` component.
 
-For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. Note`queryID` is required property and we can populate automatically by calling a method on the same instance.
+For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. Note `queryID` is required property and we can populate it automatically by calling a method on the same instance.
 
 ```jsx
 import { useAnalytics } from '@appbaseio/reactivesearch'

--- a/content/docs/reactivesearch/vue/advanced/analytics.md
+++ b/content/docs/reactivesearch/vue/advanced/analytics.md
@@ -97,7 +97,7 @@ For an example,
 
 We can use the **@appbaseio/analytics** library without installing it or any configuration by using the [**inject** API](https://vuejs.org/guide/components/provide-inject.html). When used, it returns an instance of the [analytics library](https://github.com/appbaseio/analytics.js). It uses the **url** and **credentials** provided to the parent `ReactiveBase` component.
 
-For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. 
+For example, if we want to track conversions when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. 
 
 We make a new file **VisitStoreButton.vue** using the [SFC format](https://vuejs.org/guide/scaling-up/sfc.htm) from Vue. The analytics instance is provided as `$analytics` prop. Note `queryID` is required property and we can populate it automatically by calling a method on the same instance.
 

--- a/content/docs/reactivesearch/vue/advanced/analytics.md
+++ b/content/docs/reactivesearch/vue/advanced/analytics.md
@@ -99,7 +99,7 @@ We can use the **@appbaseio/analytics** library without installing it or any con
 
 For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. 
 
-We make a new file **VisitStoreButton.vue** using the [SFC format](https://vuejs.org/guide/scaling-up/sfc.htm) from Vue. The analytics instance is provided as **$analytics** prop. Note`queryID` is required property and we can populate automatically by calling a method on the same instance.
+We make a new file **VisitStoreButton.vue** using the [SFC format](https://vuejs.org/guide/scaling-up/sfc.htm) from Vue. The analytics instance is provided as `$analytics` prop. Note`queryID` is required property and we can populate automatically by calling a method on the same instance.
 
 
 ```html

--- a/content/docs/reactivesearch/vue/advanced/analytics.md
+++ b/content/docs/reactivesearch/vue/advanced/analytics.md
@@ -99,7 +99,7 @@ We can use the **@appbaseio/analytics** library without installing it or any con
 
 For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. 
 
-We make a new file **VisitStoreButton.vue** using the [SFC format](https://vuejs.org/guide/scaling-up/sfc.htm) from Vue. The analytics instance is provided as `$analytics` prop. Note`queryID` is required property and we can populate automatically by calling a method on the same instance.
+We make a new file **VisitStoreButton.vue** using the [SFC format](https://vuejs.org/guide/scaling-up/sfc.htm) from Vue. The analytics instance is provided as `$analytics` prop. Note `queryID` is required property and we can populate it automatically by calling a method on the same instance.
 
 
 ```html

--- a/content/docs/reactivesearch/vue/advanced/analytics.md
+++ b/content/docs/reactivesearch/vue/advanced/analytics.md
@@ -93,6 +93,44 @@ For an example,
 </reactive-list>
 ```
 
+## Configure with **inject** API
+
+We can use the **@appbaseio/analytics** library without installing it or any configuration by using the [**inject** API](https://vuejs.org/guide/components/provide-inject.html). When used, it returns an instance of the [analytics library](https://github.com/appbaseio/analytics.js). It uses the **url** and **credentials** provided to the parent `ReactiveBase` component.
+
+For example, if we want to track conversions for when a user clicks on **"Visit Store"** button then we can make a button as shown in snippet below. 
+
+We make a new file **VisitStoreButton.vue** using the [SFC format](https://vuejs.org/guide/scaling-up/sfc.htm) from Vue. The analytics instance is provided as **$analytics** prop. Note`queryID` is required property and we can populate automatically by calling a method on the same instance.
+
+
+```html
+<template>
+	<button class="visit-store-btn" @click="handleVisitStore">Visit Store</button>
+</template>
+<script>
+export default {
+    name: 'VisitStoreButton',
+    inject: {
+		$analytics: {
+			default: null
+        }
+	},
+    methods: {
+        handleVisitStore() {
+            this.$analytics.conversion({
+                queryID: this.$analytics.getQueryID(),
+                objects: ['Harry Potter', 'Frankenstein'],
+            })
+		}
+	}
+}
+</script>
+```
+
+You can also view the complete demo as a codesanbox example below. 
+
+<iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/vue/examples/analytics-with-hook" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+
+
 ## Configure the analytics experience
 You can define the `appbaseConfig` prop in the `ReactiveBase` component to customize the analytics experience when appbase.io is used as a backend. It accepts an object which has the following properties:
 - **recordAnalytics** `Boolean` allows recording search analytics (and click analytics) when set to `true` and appbase.io is used as a backend. Defaults to `false`.

--- a/content/docs/reactivesearch/vue/advanced/analytics.md
+++ b/content/docs/reactivesearch/vue/advanced/analytics.md
@@ -126,7 +126,7 @@ export default {
 </script>
 ```
 
-You can also view the complete demo as a codesanbox example below. 
+You can also view the complete demo as a codesandbox example below. 
 
 <iframe src="https://codesandbox.io/embed/github/appbaseio/reactivesearch/tree/next/packages/vue/examples/analytics-with-hook" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 


### PR DESCRIPTION
**@appbaseio/reactivesearch** now uses **@appbaseio/analytics** library internally. Users can also use the same internal instance without additional configuration. This documentation shows the usage of the API and has complete examples as well.