### PR TITLE
Add a fix for edge case when only a single engine is supported

### DIFF
--- a/utils/auto-schema.js
+++ b/utils/auto-schema.js
@@ -135,6 +135,12 @@ function parsePropertiesFromLevel(propertyContainer, level, markdownStr, key, en
     var enginesSupported = propertyContainer.engine
     var requiredProps = propertyContainer.required
 
+    // Sometimes if only one engine is supported, the enginesSupported value
+    // will be a string, we will need to make it an array of one item
+    if (typeof enginesSupported === "string") {
+        enginesSupported = [enginesSupported]
+    }
+
     // Set the previous required props to empty if it's undefined
     if (previousReqProps == undefined || previousReqProps == null) {
         previousReqProps = []


### PR DESCRIPTION
Thank you for considering to contribute to reactivesearch.io docs!

**Before submitting a pull request,** please make sure that the following is done:

- [x] Describe the proposed changes and how it'll improve the docs experience
- [x] Please make sure that there are no indentation errors with rendering the docs

The script that automatically updates the schema uses the schema json by fetching it from RS. This JSON has an edge case where if the engine supported is only one than it is returned as a direct string instead of a string array.

This PR fixes that edge case by considering this scenario and adding a work-around for this.
