### PR TITLE
feat(vue): q-n-a searchbox integration 

### DIFF
--- a/content/docs/reactivesearch/vue/search/SearchBox.md
+++ b/content/docs/reactivesearch/vue/search/SearchBox.md
@@ -715,12 +715,11 @@ It accepts an object with these properties:
     The list of document objects corresponding to the `documentIds`, used for curating the AI answer.
   - **`showAIScreen`**: `Boolean`
     Boolean value to indicate when to show the AI screen.     
+  - **`isAILoading`**: `Boolean`
+    Loading status for the AI response.
+  - **`AIError`**: `Object`
+    Error returned while fetching the AI response.
 
-| Type | Optional |
-|------|----------|
-|  `object` |   Yes   |
-
-  method can be used to register click analytics for suggestions. It accepts two arguments, click position and document ID (required only if you're using `rawData` to render suggestions).
 
 You can use `SearchBox` with `render slot` as shown:
 
@@ -743,7 +742,9 @@ You can use `SearchBox` with `render slot` as shown:
         documentIds,
         loading,
         sources,
-        showAIScreen
+        showAIScreen,
+        isAILoading,
+        AIError
       }
 		}"
   >

--- a/content/docs/reactivesearch/vue/search/SearchBox.md
+++ b/content/docs/reactivesearch/vue/search/SearchBox.md
@@ -402,8 +402,8 @@ Accepts the following properties:
 -   **showFeedback** `Boolean` [optional]
     Toggles displaying the feedback UI component to record AI session's feedback. Defaults to true.
     > Use in conjunction with `reactivesearchAPIConfig.recordAnalytics` set to true in ReactiveBase.
--   **loaderMessage** `String | JSX` [optional]
-    Loading message to show when the AI Answer response is loading. The default value is: `Computing an answer from the top documents...`
+-   **loaderMessage** `String` [optional]
+    Loading message to show when the AI Answer response is loading. The default value is: `Computing an answer from the top documents...`. User `#AILoaderMessage` slot-scope for custom html markup.
 -   **showSourceDocuments** `Boolean` [optional]
     Whether to show the documents from which the AIAnswer is generated or not. Defaults to `true`.
 -   **sourceDocumentLabel** `String` [optional]
@@ -412,31 +412,6 @@ Accepts the following properties:
     callback to handle side-effects when a source button is clicked. Accepts a `sourceObj` param associated with the source button clicked.
 -   **askButton** `Boolean` [optional]
     When set to `true`, the AI answer action and the corresponding display of AIAnswer would be triggered when user presses the Ask button. Defaults to `false`. You can provide styles with `ask-button` key for the `innerClass` prop.
--   **renderAskButton** `number` [optional]
-    renders a custom jsx markup for the enter button. Use in conjunction with `askButton` prop set to `true`.
-    ```jsx
-    <SearchBox
-        id="search-component"
-        AIUIConfig={{
-            askButton: true,
-            renderAskButton: function (clickHandler){
-                return (
-                    <div
-                        style={{
-                            height: '100%',
-                            display: 'flex',
-                            alignItems: 'stretch',
-                        }}
-                    >
-                        <button style={{ border: '1px solid #c3c3c3' }} onClick={clickHandler}>
-                            🔍 Ask!
-                        </button>
-                    </div>
-            )}
-        }}
-        enterButton
-    />
-    ```
 
 ### strictSelection
 
@@ -1133,6 +1108,95 @@ It accepts an object with these properties:
   </search-box>
 ```
 
+
+
+### renderAIAnswer
+
+| Type | Optional |
+|------|----------|
+|  `slot-scope` |   Yes   |
+
+to custom render tags when mode is set to `tag`.
+Provides 
+It accepts an object with these properties:
+- **`question`**: `String`
+  The current asked question.
+- **`answer`**: `String`
+  Answer returned by the AI.   
+- **`documentIds`**: `Array<String>`
+  The documents' ids used for curating the AI answer.
+- **`loading`**: `Boolean`
+  Loading status for the AI response.
+- **`sources`**: `Array<Object>`
+  The list of document objects corresponding to the `documentIds`, used for curating the AI answer.
+
+
+```jsx
+  <search-box
+      ...
+      :mode="tag"
+      :innerClass="{
+         'selected-tag': '...'
+      }"
+  >
+		<template #renderAIAnswer="{ question, answer, documentIds, loading, sources}">
+			// render custom AI screen
+		</template>
+  </search-box>
+```
+
+### AILoaderMessage
+
+| Type | Optional |
+|------|----------|
+|  `slot-scope` |   Yes   |
+
+to custom render the loader message for AI screen
+
+```jsx
+  <search-box
+      ...
+      :mode="tag"
+      :innerClass="{
+         'selected-tag': '...'
+      }"
+  >
+		<template #AILoaderMessage>
+			// render custom AI screen loader message
+      <div> loading AI ... ⏰</div>
+		</template>
+  </search-box>
+```
+
+### renderAskButton
+
+| Type | Optional |
+|------|----------|
+|  `slot-scope` |   Yes   |
+
+The custom HTML markup displayed for enterButton. Use in conjunction with `askButton` prop under `AIUIConfig` prop set to `true`.
+
+```jsx
+<search-box
+      ...
+      :AIUIConfig="{
+        askButton: true
+      }"
+>
+    <template
+        #renderAskButton="onClick"
+    >
+      <div :style="{ height: '100%', display: 'flex', alignItems: 'stretch' }">
+         <button
+            :style="{ border: '1px solid #c3c3c3', cursor: 'pointer' }"
+            v-on:click="onClick"
+        >
+            Ask ❓
+        </button>
+      </div>
+    </template>
+</search-box>
+```
 
 ## Demo
 

--- a/content/docs/reactivesearch/vue/search/SearchBox.md
+++ b/content/docs/reactivesearch/vue/search/SearchBox.md
@@ -358,6 +358,86 @@ set placeholder text to be shown in the component's input field. Defaults to "Se
 |  `Boolean` |   Yes   |
 
 set whether the autosuggest functionality should be enabled or disabled. Defaults to `true`. When set to `false`, it searches as user types, unless `debounce` is also set.
+
+
+### enableAI
+
+| Type | Optional |
+|------|----------|
+|  `Boolean` |   Yes   |
+
+enables the ability to ask questions with SearchBox and display AI generated answers from within SearchBox component itself. Defaults to `false`.
+
+### AIConfig
+
+| Type | Optional |
+|------|----------|
+|  `Object` |   Yes   |
+
+Specify additional options for configuring the LLM context + prompt for AI answer.
+
+Accepts the following properties:
+-   **systemPrompt** `String` [optional]
+    The system prompt to send as the first message to ChatGPT. Defaults to `You are a helpful assistant`.
+-   **docTemplate** `String` [optional]
+    Template to use for building the message sent to ChatGPT for every hit of the response. The `docTemplate` string supports dynamic values using the special syntax `${}`. These values are resolved while the ChatGPT request body is built. It supports keys that are present in the `_source` field in the response hits. As an example, `source.title` will resolve to `_source.title`. If values are not found, defaults to an empty string.
+-   **queryTemplate** `String` [optional]
+    Template to use for building the message that is sent to ChatGPT as the final question. Defaults to `Can you tell me about ${value}` where `value` is the `query.value`. The querytemplate string supports a dynamic value of `value` which is the query.value of the query.
+-   **topDocsForContext** `number` [optional]
+    Number of docs to use to build the context. Defaults to 3. This has an upper limit as the total number of hits returned.  
+-   **maxTokens** `number` [optional]
+    The maximum tokens that can be used for the output. Deafults to being dynamically calculated. Accepts a value between [1, 8000].
+-   **temperatue** `number` [optional]
+    A control for randomness, a lower value implies a more deterministic output. Defaults to 1, valid values are between [0, 2].
+
+### AIUIConfig
+
+| Type | Optional |
+|------|----------|
+|  `Object` |   Yes   |
+
+Specify additional options for configruing AI screen.
+
+Accepts the following properties:
+-   **showFeedback** `Boolean` [optional]
+    Toggles displaying the feedback UI component to record AI session's feedback. Defaults to true.
+    > Use in conjunction with `reactivesearchAPIConfig.recordAnalytics` set to true in ReactiveBase.
+-   **loaderMessage** `String | JSX` [optional]
+    Loading message to show when the AI Answer response is loading. The default value is: `Computing an answer from the top documents...`
+-   **showSourceDocuments** `Boolean` [optional]
+    Whether to show the documents from which the AIAnswer is generated or not. Defaults to `true`.
+-   **sourceDocumentLabel** `String` [optional]
+    Set the label using the string literal syntax: e.g. `${source.field}` will set the label to the field’s resolved value, you can also combine more than one field value to display the label. Defaults to `_id`.
+-   **onSourceClick** `Function` [optional]
+    callback to handle side-effects when a source button is clicked. Accepts a `sourceObj` param associated with the source button clicked.
+-   **askButton** `Boolean` [optional]
+    When set to `true`, the AI answer action and the corresponding display of AIAnswer would be triggered when user presses the Ask button. Defaults to `false`. You can provide styles with `ask-button` key for the `innerClass` prop.
+-   **renderAskButton** `number` [optional]
+    renders a custom jsx markup for the enter button. Use in conjunction with `askButton` prop set to `true`.
+    ```jsx
+    <SearchBox
+        id="search-component"
+        AIUIConfig={{
+            askButton: true,
+            renderAskButton: function (clickHandler){
+                return (
+                    <div
+                        style={{
+                            height: '100%',
+                            display: 'flex',
+                            alignItems: 'stretch',
+                        }}
+                    >
+                        <button style={{ border: '1px solid #c3c3c3' }} onClick={clickHandler}>
+                            🔍 Ask!
+                        </button>
+                    </div>
+            )}
+        }}
+        enterButton
+    />
+    ```
+
 ### strictSelection
 
 | Type | Optional |
@@ -645,7 +725,21 @@ It accepts an object with these properties:
     Returns the events you should apply to any menu item elements you render.
   - **highlightedIndex** `number`
     The index that should be highlighted.
-
+- **`AIData`**: `Object`
+  A wrapper object to provide access to AI screen properties. Use in conjunction with `enableAI` set to true.
+  It contains the following keys:
+  - **`question`**: `String`
+          The current asked question.
+  - **`answer`**: `String`
+    Answer returned by the AI.   
+  - **`documentIds`**: `Array<String>`
+    The documents' ids used for curating the AI answer.
+  - **`loading`**: `Boolean`
+    Loading status for the AI response.
+  - **`sources`**: `Array<Object>`
+    The list of document objects corresponding to the `documentIds`, used for curating the AI answer.
+  - **`showAIScreen`**: `Boolean`
+    Boolean value to indicate when to show the AI screen.     
 
 | Type | Optional |
 |------|----------|
@@ -668,6 +762,14 @@ You can use `SearchBox` with `render slot` as shown:
 			loading,
 			downshiftProps: { isOpen, highlightedIndex, getItemProps, getItemEvents },
 			data: suggestions,
+      AIData: {
+        question,
+        answer,
+        documentIds,
+        loading,
+        sources,
+        showAIScreen
+      }
 		}"
   >
     <div class="suggestions">
@@ -1048,6 +1150,9 @@ It accepts an object with these properties:
 - `popular-search-icon`
 - `enter-button`
 - `selected-tag`
+- `ask-button`
+- `ai-source-tag`
+- `ai-feedback`
 
 Read more about it [here](/docs/reactivesearch/vue/theming/ClassnameInjection/).
 


### PR DESCRIPTION
**PR Type** `feat`

**Description** The PR adds props def for q-n-a integration in SearchBox.

[📔 Notion](https://www.notion.so/Vue-JS-AIAnswer-in-SearchBox-efcb0382399548c1982f5c41abeb4015)

https://github.com/appbaseio/reactivesearch/pull/2214