### PR TITLE
Demo migration P0: Render RS API credentials and migration utils

### DIFF
--- a/content/api/javascript/quickstart.md
+++ b/content/api/javascript/quickstart.md
@@ -33,7 +33,7 @@ This gif shows how to create an index on reactivesearch.io cluster, which we wil
 
 ![](https://www.dropbox.com/s/qa5nazj2ajaskr6/wky0vrsPPB.gif?raw=1)
 
-For this tutorial, we will use an index called `good-books-demo`. The credentials for this index are `376aa692e5ab:8472bf31-b18a-454d-bd39-257c07d02854`.
+For this tutorial, we will use an index called `good-books-ds`. The credentials are `d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0`.
 
 > Note <i class="fa fa-info-circle"></i>
 >
@@ -59,9 +59,9 @@ To write data to [appbase.io](https://reactivesearch.io), we need to first creat
 
 ```js
 var appbaseRef = Appbase({
-	url: 'https://appbase-demo-ansible-abxiydt-arc.searchbase.io',
-	app: 'good-books-demo',
-	credentials: 'c84fb24cbe08:db2a25b5-1267-404f-b8e6-cf0754953c68',
+	url: 'https://reactivesearch-api-9-3-0.onrender.com',
+	app: 'good-books-ds',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 });
 ```
 
@@ -69,9 +69,8 @@ var appbaseRef = Appbase({
 
 ```js
 var appbaseRef = Appbase({
-	url:
-		'https://c84fb24cbe08:db2a25b5-1267-404f-b8e6-cf0754953c68@appbase-demo-ansible-abxiydt-arc.searchbase.io',
-	app: 'good-books-demo',
+	url: 'https://d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0@reactivesearch-api-9-3-0.onrender.com',
+	app: 'good-books-ds',
 });
 ```
 
@@ -128,7 +127,7 @@ appbaseRef.get({
 
 /* get() response */
 {
- "_index": "good-books-demo",
+ "_index": "good-books-ds",
  "_type": "books",
  "_id": "X1",
  "_version": 5,

--- a/content/api/javascript/quickstart.md
+++ b/content/api/javascript/quickstart.md
@@ -59,7 +59,7 @@ To write data to [appbase.io](https://reactivesearch.io), we need to first creat
 
 ```js
 var appbaseRef = Appbase({
-	url: 'https://reactivesearch-api-9-3-0.onrender.com',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
 	app: 'good-books-ds',
 	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
 });
@@ -69,7 +69,7 @@ var appbaseRef = Appbase({
 
 ```js
 var appbaseRef = Appbase({
-	url: 'https://d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0@reactivesearch-api-9-3-0.onrender.com',
+	url: 'https://d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0@reactivesearch-api-9-4-0.onrender.com',
 	app: 'good-books-ds',
 });
 ```

--- a/content/docs/reactivesearch/react-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/react-searchbox/quickstart.md
@@ -48,7 +48,7 @@ export default () => (
 	<SearchBase
 		index="good-books-ds"
 		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
-		url="https://reactivesearch-api-9-3-0.onrender.com"
+		url="https://reactivesearch-api-9-4-0.onrender.com"
 	>
 		<div>
 			<SearchBox
@@ -147,7 +147,7 @@ export default () => (
   <SearchBase
     index="good-books-ds"
     credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
-    url="https://reactivesearch-api-9-3-0.onrender.com"
+    url="https://reactivesearch-api-9-4-0.onrender.com"
   >
     <div>
       <SearchBox

--- a/content/docs/reactivesearch/react-searchbox/quickstart.md
+++ b/content/docs/reactivesearch/react-searchbox/quickstart.md
@@ -47,8 +47,8 @@ import { SearchBox, SearchBase, SearchComponent } from '@appbaseio/react-searchb
 export default () => (
 	<SearchBase
 		index="good-books-ds"
-		credentials="a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61"
-		url="https://arc-cluster-appbase-demo-6pjy6z.searchbase.io"
+		credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
+		url="https://reactivesearch-api-9-3-0.onrender.com"
 	>
 		<div>
 			<SearchBox
@@ -146,8 +146,8 @@ import {
 export default () => (
   <SearchBase
     index="good-books-ds"
-    credentials="a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61"
-    url="https://arc-cluster-appbase-demo-6pjy6z.searchbase.io"
+    credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
+    url="https://reactivesearch-api-9-3-0.onrender.com"
   >
     <div>
       <SearchBox

--- a/content/docs/reactivesearch/react/list/singlelist.md
+++ b/content/docs/reactivesearch/react/list/singlelist.md
@@ -51,9 +51,9 @@ Example uses:
 	URLParams={false}
 	loader="Loading ..."
     endpoint={{
-      url:"https://appbase-demo-ansible-abxiydt-arc.searchbase.io/recipes-demo/_reactivesearch.v3", //mandatory
+      url:"https://reactivesearch-api-9-3-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
       headers:{
-        // relevant headers
+        Authorization: 'Basic ZDAzZTZmNWYzM2Q1OjQ5MTI0Njc0LTU1NGUtNDM0My05YWIyLTAwNmIyOTMyZjVjMA=='
       },
       method: 'POST'
     }}        

--- a/content/docs/reactivesearch/react/list/singlelist.md
+++ b/content/docs/reactivesearch/react/list/singlelist.md
@@ -51,7 +51,7 @@ Example uses:
 	URLParams={false}
 	loader="Loading ..."
     endpoint={{
-      url:"https://reactivesearch-api-9-3-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
+      url:"https://reactivesearch-api-9-4-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
       headers:{
         Authorization: 'Basic ZDAzZTZmNWYzM2Q1OjQ5MTI0Njc0LTU1NGUtNDM0My05YWIyLTAwNmIyOTMyZjVjMA=='
       },

--- a/content/docs/reactivesearch/react/overview/quickstart.md
+++ b/content/docs/reactivesearch/react/overview/quickstart.md
@@ -57,7 +57,7 @@ Lets add our first ReactiveSearch component: [ReactiveBase](/docs/reactivesearch
 
 ![create an appbase.io index](https://www.dropbox.com/s/qa5nazj2ajaskr6/wky0vrsPPB.gif?raw=1)
 
-**Caption:** For the example that we will build in this tutorial, the app is called **good-books-ds** and the associated read-only credentials are **04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31**. You can browse and export the dataset to JSON or CSV from [here](https://dejavu.appbase.io/?appname=good-books-ds&url=https://04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31@appbase-demo-ansible-abxiydt-arc.searchbase.io&mode=edit).
+**Caption:** For the example that we will build in this tutorial, the app is called **good-books-ds** and the associated credentials are **d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0**. Browse the dataset via the [ReactiveSearch API](https://reactivesearch-api-9-3-0.onrender.com) or import your own copy.
 
 **Note:** Clone app option will not work with these credentials here have very narrow access scope (to prevent abuse).
 
@@ -70,9 +70,9 @@ import { ReactiveBase } from "@appbaseio/reactivesearch";
 function App() {
   return (
     <ReactiveBase
-      url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-3-0.onrender.com"
       app="good-books-ds"
-      credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       {/* Our components will go over here */}
       Hello from ReactiveSearch 👋

--- a/content/docs/reactivesearch/react/overview/quickstart.md
+++ b/content/docs/reactivesearch/react/overview/quickstart.md
@@ -57,7 +57,7 @@ Lets add our first ReactiveSearch component: [ReactiveBase](/docs/reactivesearch
 
 ![create an appbase.io index](https://www.dropbox.com/s/qa5nazj2ajaskr6/wky0vrsPPB.gif?raw=1)
 
-**Caption:** For the example that we will build in this tutorial, the app is called **good-books-ds** and the associated credentials are **d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0**. Browse the dataset via the [ReactiveSearch API](https://reactivesearch-api-9-3-0.onrender.com) or import your own copy.
+**Caption:** For the example that we will build in this tutorial, the app is called **good-books-ds** and the associated credentials are **d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0**. Browse the dataset via the [ReactiveSearch API](https://reactivesearch-api-9-4-0.onrender.com) or import your own copy.
 
 **Note:** Clone app option will not work with these credentials here have very narrow access scope (to prevent abuse).
 
@@ -70,7 +70,7 @@ import { ReactiveBase } from "@appbaseio/reactivesearch";
 function App() {
   return (
     <ReactiveBase
-      url="https://reactivesearch-api-9-3-0.onrender.com"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
       app="good-books-ds"
       credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >

--- a/content/docs/reactivesearch/react/result/reactivelist.md
+++ b/content/docs/reactivesearch/react/result/reactivelist.md
@@ -65,7 +65,7 @@ Example uses:
     	and: ['CitySensor', 'SearchSensor'],
     }}
     endpoint={{
-      url:"https://reactivesearch-api-9-3-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
+      url:"https://reactivesearch-api-9-4-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
       headers:{
         Authorization: 'Basic ZDAzZTZmNWYzM2Q1OjQ5MTI0Njc0LTU1NGUtNDM0My05YWIyLTAwNmIyOTMyZjVjMA=='
       },

--- a/content/docs/reactivesearch/react/result/reactivelist.md
+++ b/content/docs/reactivesearch/react/result/reactivelist.md
@@ -65,9 +65,9 @@ Example uses:
     	and: ['CitySensor', 'SearchSensor'],
     }}
     endpoint={{
-      url:"https://appbase-demo-ansible-abxiydt-arc.searchbase.io/recipes-demo/_reactivesearch.v3", //mandatory
+      url:"https://reactivesearch-api-9-3-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
       headers:{
-        // relevant headers
+        Authorization: 'Basic ZDAzZTZmNWYzM2Q1OjQ5MTI0Njc0LTU1NGUtNDM0My05YWIyLTAwNmIyOTMyZjVjMA=='
       },
       method: 'POST'
     }}    

--- a/content/docs/reactivesearch/react/search/searchbox.md
+++ b/content/docs/reactivesearch/react/search/searchbox.md
@@ -95,7 +95,7 @@ Example uses:
         }}
         renderNoSuggestion="No suggestions found"
         endpoint={{
-            url:"https://reactivesearch-api-9-3-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
+            url:"https://reactivesearch-api-9-4-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
             headers:{
                 Authorization: 'Basic ZDAzZTZmNWYzM2Q1OjQ5MTI0Njc0LTU1NGUtNDM0My05YWIyLTAwNmIyOTMyZjVjMA=='
             },

--- a/content/docs/reactivesearch/react/search/searchbox.md
+++ b/content/docs/reactivesearch/react/search/searchbox.md
@@ -95,9 +95,9 @@ Example uses:
         }}
         renderNoSuggestion="No suggestions found"
         endpoint={{
-            url:"https://appbase-demo-ansible-abxiydt-arc.searchbase.io/recipes-demo/_reactivesearch.v3", //mandatory
+            url:"https://reactivesearch-api-9-3-0.onrender.com/recipes-demo/_reactivesearch", //mandatory
             headers:{
-                // relevant headers
+                Authorization: 'Basic ZDAzZTZmNWYzM2Q1OjQ5MTI0Njc0LTU1NGUtNDM0My05YWIyLTAwNmIyOTMyZjVjMA=='
             },
             method: 'POST'
         }}            

--- a/content/docs/reactivesearch/searchbase/overview/QuickStart.md
+++ b/content/docs/reactivesearch/searchbase/overview/QuickStart.md
@@ -44,16 +44,16 @@ import { SearchComponent } from '@appbaseio/searchbase';
 // Instantiate the `SearchComponent`
 const searchComponent = new SearchComponent({
 	// Elasticsearch index name
-	index: 'gitxplore-app',
+	index: 'good-books-ds',
 	// Appbase credentials
-	credentials: 'a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61',
-	url: 'https://@arc-cluster-appbase-demo-6pjy6z.searchbase.io',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
+	url: 'https://reactivesearch-api-9-3-0.onrender.com',
 	// Unique identifier for component
 	id: 'search-component',
 	// initialize with empty value
 	value: '',
 	// Database fields to perform the search
-	dataField: ['name', 'description', 'name.search', 'fullname', 'owner', 'topics'],
+	dataField: ['title', 'original_title', 'authors'],
 });
 
 // Get the input element
@@ -118,24 +118,24 @@ import { SearchBase } from '@appbaseio/searchbase';
 // Instantiate the `SearchBase`
 const searchbase = new SearchBase({
 	// Elasticsearch index name
-	index: 'gitxplore-app',
+	index: 'good-books-ds',
 	// Appbase credentials
-	credentials: 'a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61',
-	url: 'https://@arc-cluster-appbase-demo-6pjy6z.searchbase.io',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
+	url: 'https://reactivesearch-api-9-3-0.onrender.com',
 });
 
 // Register search component => To render the suggestions
 const searchComponent = searchbase.register('search-component', {
 	// pass this prop as true to enable predictive suggestions
 	enablePredictiveSuggestions: true,
-	dataField: ['name', 'description', 'name.raw', 'fullname', 'owner', 'topics'],
+	dataField: ['title', 'original_title', 'authors'],
 });
 
 // Register filter component with dependency on search component
 const filterComponent = searchbase.register('language-filter', {
 	// The type property as `term` is to use the Elasticsearch terms aggregations.
 	type: 'term',
-	dataField: 'language.keyword',
+	dataField: 'language_code.keyword',
 	react: {
 		and: 'search-component',
 	},
@@ -143,7 +143,7 @@ const filterComponent = searchbase.register('language-filter', {
 
 // Register result component with react dependency on search and filter component => To render the results
 const resultComponent = searchbase.register('result-component', {
-	dataField: 'name',
+	dataField: 'title',
 	react: {
 		and: ['search-component', 'language-filter'],
 	},

--- a/content/docs/reactivesearch/searchbase/overview/QuickStart.md
+++ b/content/docs/reactivesearch/searchbase/overview/QuickStart.md
@@ -47,7 +47,7 @@ const searchComponent = new SearchComponent({
 	index: 'good-books-ds',
 	// Appbase credentials
 	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
-	url: 'https://reactivesearch-api-9-3-0.onrender.com',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
 	// Unique identifier for component
 	id: 'search-component',
 	// initialize with empty value
@@ -121,7 +121,7 @@ const searchbase = new SearchBase({
 	index: 'good-books-ds',
 	// Appbase credentials
 	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
-	url: 'https://reactivesearch-api-9-3-0.onrender.com',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
 });
 
 // Register search component => To render the suggestions

--- a/content/docs/reactivesearch/vue/overview/QuickStart.md
+++ b/content/docs/reactivesearch/vue/overview/QuickStart.md
@@ -106,7 +106,7 @@ We will demonstrate creating an index using [appbase.io](https://appbase.io) ser
 
 ![create an appbase.io app](https://www.dropbox.com/s/qa5nazj2ajaskr6/wky0vrsPPB.gif?raw=1)
 
-**Caption:** For the example that we will build, the app is called **good-books-ds** and the associated credentials are **d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0**. Browse the dataset via the [ReactiveSearch API](https://reactivesearch-api-9-3-0.onrender.com).
+**Caption:** For the example that we will build, the app is called **good-books-ds** and the associated credentials are **d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0**. Browse the dataset via the [ReactiveSearch API](https://reactivesearch-api-9-4-0.onrender.com).
 
 **Note:** Clone app option will not work with these credentials here have very narrow access scope (to prevent abuse).
 
@@ -116,7 +116,7 @@ We will update our `src/App.vue` file to add the ReactiveBase component.
 <template>
 	<div id="app">
 		<reactive-base
-			url="https://reactivesearch-api-9-3-0.onrender.com"
+			url="https://reactivesearch-api-9-4-0.onrender.com"
 			app="good-books-ds"
 			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
@@ -248,7 +248,7 @@ Now, we will put all three components together to create the UI view.
 <template>
   <div id="app">
     <reactive-base
-      url="https://reactivesearch-api-9-3-0.onrender.com"
+      url="https://reactivesearch-api-9-4-0.onrender.com"
       app="good-books-ds"
       credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >

--- a/content/docs/reactivesearch/vue/overview/QuickStart.md
+++ b/content/docs/reactivesearch/vue/overview/QuickStart.md
@@ -106,7 +106,7 @@ We will demonstrate creating an index using [appbase.io](https://appbase.io) ser
 
 ![create an appbase.io app](https://www.dropbox.com/s/qa5nazj2ajaskr6/wky0vrsPPB.gif?raw=1)
 
-**Caption:** For the example that we will build, the app is called **good-books-ds** and the associated read-only credentials are **04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31**. You can browse and export the dataset to JSON or CSV from [here].(https://dejavu.appbase.io/?appname=good-books-ds&url=https://04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31@appbase-demo-ansible-abxiydt-arc.searchbase.io&mode=edit).
+**Caption:** For the example that we will build, the app is called **good-books-ds** and the associated credentials are **d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0**. Browse the dataset via the [ReactiveSearch API](https://reactivesearch-api-9-3-0.onrender.com).
 
 **Note:** Clone app option will not work with these credentials here have very narrow access scope (to prevent abuse).
 
@@ -116,9 +116,9 @@ We will update our `src/App.vue` file to add the ReactiveBase component.
 <template>
 	<div id="app">
 		<reactive-base
-			url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+			url="https://reactivesearch-api-9-3-0.onrender.com"
 			app="good-books-ds"
-			credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+			credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
 		>
 			<h1>Hello from ReactiveBase 👋</h1>
 		</reactive-base>
@@ -248,9 +248,9 @@ Now, we will put all three components together to create the UI view.
 <template>
   <div id="app">
     <reactive-base
-      url="https://appbase-demo-ansible-abxiydt-arc.searchbase.io"
+      url="https://reactivesearch-api-9-3-0.onrender.com"
       app="good-books-ds"
-      credentials="04717bb076f7:be54685e-db84-4243-975b-5b32ee241d31"
+      credentials="d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0"
     >
       <search-box
         componentId="SearchBox"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
 		"react-router": "^7.15.1",
 		"react-router-dom": "^4.3.1",
 		"react-use-fusejs": "^1.0.1",
-		"searchbox-showcase": "https://github.com/awesome-reactivesearch/searchbox-showcase.git#ac58bba",
+		"searchbox-showcase": "https://github.com/awesome-reactivesearch/searchbox-showcase.git#fd402658",
 		"tocbot": "^4.18.0",
 		"yarn": "^1.22.18"
 	},

--- a/src/pages/docs/reactivesearch/react/overview/Showcase.js
+++ b/src/pages/docs/reactivesearch/react/overview/Showcase.js
@@ -20,7 +20,7 @@ import ShowcaseComponent from '../../../../../components/ShowcaseComponent';
 const settings = {
 	app: 'clone-airbeds',
 	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
-	url: 'https://reactivesearch-api-9-3-0.onrender.com',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
 	enableAppbase: true,
 	mapKey: 'AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU',
 	mapLibraries: ['places'],

--- a/src/pages/docs/reactivesearch/react/overview/Showcase.js
+++ b/src/pages/docs/reactivesearch/react/overview/Showcase.js
@@ -19,8 +19,8 @@ import ShowcaseComponent from '../../../../../components/ShowcaseComponent';
 
 const settings = {
 	app: 'clone-airbeds',
-	credentials: '3f7ed293fbe0:47ff004a-4722-49fe-bc48-0ff0286e4de0',
-	url: 'https://appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
+	url: 'https://reactivesearch-api-9-3-0.onrender.com',
 	enableAppbase: true,
 	mapKey: 'AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU',
 	mapLibraries: ['places'],

--- a/src/pages/docs/reactivesearch/vue/overview/Showcase.js
+++ b/src/pages/docs/reactivesearch/vue/overview/Showcase.js
@@ -16,8 +16,8 @@ import ShowcaseComponent from '../../../../../components/ShowcaseComponent';
 
 const settings = {
 	app: 'clone-airbeds',
-	credentials: '3f7ed293fbe0:47ff004a-4722-49fe-bc48-0ff0286e4de0',
-    url: 'https://appbase-demo-ansible-abxiydt-arc.searchbase.io',
+	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
+	url: 'https://reactivesearch-api-9-3-0.onrender.com',
     enableAppbase: true,
     mapKey: 'AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU',
 	theme: {

--- a/src/pages/docs/reactivesearch/vue/overview/Showcase.js
+++ b/src/pages/docs/reactivesearch/vue/overview/Showcase.js
@@ -17,7 +17,7 @@ import ShowcaseComponent from '../../../../../components/ShowcaseComponent';
 const settings = {
 	app: 'clone-airbeds',
 	credentials: 'd03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0',
-	url: 'https://reactivesearch-api-9-3-0.onrender.com',
+	url: 'https://reactivesearch-api-9-4-0.onrender.com',
     enableAppbase: true,
     mapKey: 'AIzaSyA9JzjtHeXg_C_hh_GdTBdLxREWdj3nsOU',
 	theme: {

--- a/utils/demo-migration/.gitignore
+++ b/utils/demo-migration/.gitignore
@@ -1,0 +1,2 @@
+export/
+*.bulk.ndjson

--- a/utils/demo-migration/MIGRATION-READINESS.md
+++ b/utils/demo-migration/MIGRATION-READINESS.md
@@ -1,6 +1,6 @@
 # Docs Migration Readiness Report
 
-**New backend:** `https://reactivesearch-api-9-3-0.onrender.com` (`rs-demo` / `rs-password`)  
+**New backend:** `https://reactivesearch-api-9-4-0.onrender.com` (`rs-demo` / `rs-password`)  
 **Elasticsearch:** Aiven OpenSearch  
 **Last updated:** 2026-07-07
 
@@ -34,7 +34,7 @@
 ```
 OLD: https://appbase-demo-ansible-abxiydt-arc.searchbase.io
 OLD: https://arc-cluster-appbase-demo-6pjy6z.searchbase.io
-NEW: https://reactivesearch-api-9-3-0.onrender.com
+NEW: https://reactivesearch-api-9-4-0.onrender.com
 
 OLD: /recipes-demo/_reactivesearch.v3
 NEW: /good-books-ds/_reactivesearch   # interim until recipes-demo migrated
@@ -42,7 +42,7 @@ NEW: /good-books-ds/_reactivesearch   # interim until recipes-demo migrated
 
 ## P0 pages updated (2026-07-07)
 
-Backend: `https://reactivesearch-api-9-3-0.onrender.com` / `rs-demo:rs-password`
+Backend: `https://reactivesearch-api-9-4-0.onrender.com` / `rs-demo:rs-password`
 
 - `content/docs/reactivesearch/react/overview/quickstart.md`
 - `content/docs/reactivesearch/vue/overview/QuickStart.md`
@@ -121,7 +121,7 @@ Backend: `https://reactivesearch-api-9-3-0.onrender.com` / `rs-demo:rs-password`
 3. Bulk-replace hostnames in Docs + credentials
 4. Retarget `recipes-demo` demos → `good-books-ds` OR migrate subset
 5. Finish `best-buy-dataset` migration
-6. Update external repos: `reactivesearch`, `searchbox`, `autocomplete-suggestions-plugin`
+6. Update external repos: `reactivesearch` ([CSB checklist](./REACTIVESearch-CSB-CHECKLIST.md)), `searchbox`, `autocomplete-suggestions-plugin`
 7. Bulk-update `play.reactivesearch.io` saved states
 8. P0 → P1 → P2 manual test pass
 

--- a/utils/demo-migration/MIGRATION-READINESS.md
+++ b/utils/demo-migration/MIGRATION-READINESS.md
@@ -1,0 +1,141 @@
+# Docs Migration Readiness Report
+
+**New backend:** `https://reactivesearch-api-9-3-0.onrender.com` (`rs-demo` / `rs-password`)  
+**Elasticsearch:** Aiven OpenSearch  
+**Last updated:** 2026-07-07
+
+## Executive summary
+
+| Area | Status |
+|------|--------|
+| RS API health | ✅ OpenSearch 3.3.2 reachable |
+| `good-books-ds` search | ✅ Verified via `_reactivesearch` |
+| `recipes-demo` | ⏳ Importing (~17k / 222k on Aiven; see investigation below) |
+| Indexes migrated | 5 of 8 complete; 2 importing |
+| Docs hostname updates | ~130+ occurrences, ~120 files |
+| Playground embeds | ~248 iframes, ~90–120 unique IDs |
+| CodeSandbox embeds | ~200+ iframes in ~167 files (external repos) |
+
+## Indexes on Aiven
+
+| Index | Docs | Status |
+|-------|------|--------|
+| `good-books-ds` | 9,418 | ✅ |
+| `clone-airbeds` | 427 | ✅ |
+| `earthquakes` | 3,646 | ✅ |
+| `docs-demo` | 1,883 | ✅ |
+| `good-books` | 180 | ✅ |
+| `recipes-demo` | ~17k → 222,286 (10% sample) | ⏳ Import-only running (PID ~99797); export complete (444,572 bulk lines) |
+| `best-buy-dataset` | ~8.5k → 114,928 | ⏳ Import-only running (PID ~17522); export complete (229,856 bulk lines) |
+| `good-books-authors` | — | ⏭️ Not on source cluster |
+
+## Replace cheatsheet
+
+```
+OLD: https://appbase-demo-ansible-abxiydt-arc.searchbase.io
+OLD: https://arc-cluster-appbase-demo-6pjy6z.searchbase.io
+NEW: https://reactivesearch-api-9-3-0.onrender.com
+
+OLD: /recipes-demo/_reactivesearch.v3
+NEW: /good-books-ds/_reactivesearch   # interim until recipes-demo migrated
+```
+
+## P0 pages updated (2026-07-07)
+
+Backend: `https://reactivesearch-api-9-3-0.onrender.com` / `rs-demo:rs-password`
+
+- `content/docs/reactivesearch/react/overview/quickstart.md`
+- `content/docs/reactivesearch/vue/overview/QuickStart.md`
+- `content/docs/reactivesearch/searchbase/overview/QuickStart.md`
+- `content/docs/reactivesearch/react-searchbox/quickstart.md`
+- `src/pages/docs/reactivesearch/react/overview/Showcase.js`
+- `src/pages/docs/reactivesearch/vue/overview/Showcase.js`
+- `content/docs/reactivesearch/react/search/searchbox.md`
+- `content/docs/reactivesearch/react/result/reactivelist.md`
+- `content/docs/reactivesearch/react/list/singlelist.md`
+- `content/api/javascript/quickstart.md`
+
+
+| Path | Why |
+|------|-----|
+| `/docs/reactivesearch/react/overview/quickstart` | React onboarding |
+| `/docs/reactivesearch/vue/overview/QuickStart` | Vue onboarding |
+| `/docs/reactivesearch/searchbase/overview/QuickStart` | SearchBase entry |
+| `/docs/reactivesearch/react-searchbox/quickstart` | SearchBox onboarding |
+| `/docs/reactivesearch/react/overview/Showcase` | Live `clone-airbeds` demo |
+| `/docs/reactivesearch/react/search/searchbox` | Top component |
+| `/docs/reactivesearch/react/result/reactivelist` | Top component + CSB |
+| `/docs/reactivesearch/react/list/singlelist` | Facet demo (recipes-demo gap) |
+| `/api/javascript/quickstart` | API quickstart |
+
+## P1 playground-heavy pages
+
+- `/docs/search/reactivesearch-api/reference/opensearch` (44 embeds)
+- `/docs/search/reactivesearch-api/reference/elasticsearch` (44 embeds)
+- `/docs/reactivesearch/atlas-search/search-examples-with-react`
+- `/docs/reactivesearch/autocomplete-plugin/guides` (needs `best-buy-dataset`)
+- `/docs/pipelines/how-to/open-ai`
+- `/docs/analytics/popular-recent-suggestions`
+- `/api/examples/rest`
+
+**Note:** `play.reactivesearch.io` backends live in saved playground state, not iframe URLs alone.
+
+
+## Import investigation (2026-07-07 ~15:00 IST)
+
+**What happened**
+
+- Exports are **complete** on disk: `recipes-demo` 222,286 docs (162 MB NDJSON), `best-buy-dataset` 114,928 docs (759 MB).
+- Earlier full runs **did not finish**: `best-buy-dataset` export died at ~20k docs with `ConnectionResetError` from the source cluster; initial wrapper logs show start only (no completion).
+- Index create on Aiven previously failed on private OpenSearch settings until `build_create_payload()` stripped `index.history` (and related keys). Current script includes that fix.
+- **`--force` import does not delete** an existing index; it bulk-loads into it (same `_id` overwrites). The drop from “~50%” to ~5k is explained by **import-only restarts after the destination index was missing/recreated** (log: `creating best-buy-dataset…` at 09:17 UTC) and fresh bulk from line 1—not by a silent partial crash of the current run.
+- **best-buy** had **four** import-only starts (09:13, 09:17, 09:19, 09:22 UTC); only one Python importer per index is active now. No `bulk errors` in `logs/`.
+
+**Current Aiven `_count` (rising)**
+
+| Index | Count | Target | Notes |
+|-------|------:|-------:|-------|
+| `recipes-demo` | ~16.9k | 222,286 | Import-only since ~09:13 UTC |
+| `best-buy-dataset` | ~8.5k | 114,928 | Import-only since ~09:22 UTC (slower bulk) |
+
+**Processes**
+
+- `migrate-demo-indexes.py --import-only --force` running for both indexes (no `run-migration.sh` wrapper on the active PIDs).
+- **Do not start additional import-only jobs** until these finish (avoids competing bulk and confusing counts).
+
+**ETA (rough)**
+
+- `recipes-demo`: ~1–1.5 h at observed ~50–100 docs/s.
+- `best-buy-dataset`: ~2–3 h (larger docs, slower observed rate).
+
+## Migration tooling
+
+- `migrate-demo-indexes.py` — export/import; strips private settings (`history.uuid`, etc.)
+- `run-migration.sh` — logged wrapper (`logs/{index}-{timestamp}.log`, redacted URLs)
+- Wrapper jobs: `logs/best-buy-dataset-20260707T073843Z.log`, `logs/recipes-demo-20260707T073843Z.log`
+
+## Migration order
+
+1. Create per-index read-only RS credentials (replace root `rs-demo` in public docs)
+2. Configure CORS on Render for docs, CodeSandbox, playground, storybook origins
+3. Bulk-replace hostnames in Docs + credentials
+4. Retarget `recipes-demo` demos → `good-books-ds` OR migrate subset
+5. Finish `best-buy-dataset` migration
+6. Update external repos: `reactivesearch`, `searchbox`, `autocomplete-suggestions-plugin`
+7. Bulk-update `play.reactivesearch.io` saved states
+8. P0 → P1 → P2 manual test pass
+
+## External repos (not Docs)
+
+- `appbaseio/reactivesearch` — web/vue/maps examples + storybook
+- `appbaseio/searchbox` — react-searchbox examples
+- `appbaseio/autocomplete-suggestions-plugin` — blocked on `best-buy-dataset`
+- `opensource.appbase.io/playground`, `reactivesearch-vue-playground.netlify.app`
+
+## recipes-demo options
+
+| Option | Tradeoff |
+|--------|----------|
+| Migrate ~10k doc subset | Enough for facet demos |
+| Retarget demos → `good-books-ds` | Fastest; different field schema |
+| Static screenshots | Lowest effort |

--- a/utils/demo-migration/REACTIVESearch-CSB-CHECKLIST.md
+++ b/utils/demo-migration/REACTIVESearch-CSB-CHECKLIST.md
@@ -1,0 +1,358 @@
+# ReactiveSearch CodeSandbox migration checklist
+
+> **Source:** exhaustive grep of Docs repo for `codesandbox.io` URLs referencing `appbaseio/reactivesearch` (130 unique embed paths, 202 iframe occurrences across ~140 files).  
+> **Last verified:** 2026-07-26
+
+> **next branch examples migrated 2026-07-26 via reactivesearch PR #2326**
+
+---
+
+## Agent prompt (copy into reactivesearch repo)
+
+```
+Migrate CodeSandbox examples in appbaseio/reactivesearch to the new demo backend.
+
+BACKEND
+  URL:         https://reactivesearch-api-9-4-0.onrender.com
+  Credentials: d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0
+  API path:    /{index}/_reactivesearch          (NOT /_reactivesearch.v3)
+
+REPLACE CHEATSHEET (in each example's config / ReactiveBase props)
+  OLD host:  https://appbase-demo-ansible-abxiydt-arc.searchbase.io
+             https://arc-cluster-appbase-demo-6pjy6z.searchbase.io
+  NEW host:  https://reactivesearch-api-9-4-0.onrender.com
+
+  OLD path:  /recipes-demo/_reactivesearch.v3
+             /good-books-ds/_reactivesearch.v3
+  NEW path:  /{index}/_reactivesearch
+
+  OLD creds: various demo read-only keys in examples
+  NEW creds: d03e6f5f33d5:49124674-554e-4343-9ab2-006b2932f5c0
+             (replace with per-index read-only creds before public release)
+
+INDEX HINTS
+  good-books-ds  — default for search / chart / AI / preferences demos
+  clone-airbeds  — geo / maps / QuerySuggestion (analytics)
+  good-books     — multi-index demos (paired with good-books-ds)
+  recipes-demo   — facet/list/range demos; retarget to good-books-ds until
+                   recipes-demo index import completes on Render ES
+
+PER-EXAMPLE CHANGES
+  1. Update app/url, credentials, and index in ReactiveBase (or equivalent).
+  2. Drop `.v3` from `_reactivesearch` path suffix.
+  3. For recipes-demo examples: use good-books-ds interim OR wait for index.
+  4. Skip mongo-examples/* — those use MongoDB Atlas, not Render ES (see below).
+  5. vue-maps examples also need a valid Google Maps API key in env.
+
+VERIFICATION (each example)
+  [ ] CSB preview loads without console CORS / 401 errors
+  [ ] Search returns results for the configured index
+  [ ] Facets / geo / charts render (where applicable)
+  [ ] No remaining references to searchbase.io or _reactivesearch.v3
+
+P0 ALREADY DONE IN REACTIVESSEARCH (do not re-migrate)
+  next/packages/web/examples/MyAwesomeSearchStep1-5
+  next/packages/web/examples/SearchBox
+  next/packages/web/examples/SearchBoxWithPillSuggestions
+  feat/faq-suggestions/packages/web/examples/SearchBoxWithFAQSuggestions
+  next/packages/web/examples/ReactiveList
+  next/packages/web/examples/SingleList
+
+Work through the checklist below in suggested migration order.
+```
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|------:|
+| Unique CSB embed paths (reactivesearch repo) | 130 |
+| **P0 done** (excluded from checklist) | 10 |
+| **next branch done** (PR #2326, 2026-07-26) | 71 |
+| **Remaining checklist items** | 49 |
+| P1 (atlas-search + analytics) | 10 |
+| `mongo-examples` (defer / separate track) | 9 |
+| `recipes-demo` dependents (interim → good-books-ds) | ~61 |
+
+### By branch
+
+| Branch | Checklist items |
+|--------|----------------:|
+| `next` | 71 ✅ (migrated PR #2326) |
+| `feat/just-for-csb-002` | 23 |
+| `feat/vue-showcase` | 2 |
+| `feat/faq-suggestions` | 1 |
+| `dev` | 4 |
+| `v3` | 5 |
+| `vue-maps` | 4 |
+
+### By package
+
+| Package | ES examples | Mongo (defer) |
+|---------|------------:|--------------:|
+| `packages/web` (`@appbaseio/reactivesearch`) | 44 | 3 |
+| `packages/vue` (`@appbaseio/reactivesearch-vue`) | 22 + 26 on stale branches | 3 |
+| `packages/maps` | 5 | 3 |
+| `vue-maps` (legacy Google Maps) | 4 | — |
+
+### Suggested migration order
+
+1. **Stale branches** — `dev` (4), `v3` (5), `vue-maps` (4), `feat/just-for-csb-002` (23), `feat/*` showcase (3)
+2. **`next` bulk** — web (44) → vue (22) → maps (5)
+3. **`recipes-demo` dependents** — list/range/facet examples (~61); retarget to `good-books-ds` until `recipes-demo` index is on Render ES
+4. **`mongo-examples`** — skip or separate MongoDB Atlas migration (9 examples)
+
+---
+
+## P0 — already migrated ✅
+
+These 10 examples are **done** in the reactivesearch repo (Docs PR already points at Render ES for the corresponding pages). No further work unless regression found.
+
+- `next/packages/web/examples/MyAwesomeSearchStep1`
+- `next/packages/web/examples/MyAwesomeSearchStep2`
+- `next/packages/web/examples/MyAwesomeSearchStep3`
+- `next/packages/web/examples/MyAwesomeSearchStep4`
+- `next/packages/web/examples/MyAwesomeSearchStep5`
+- `next/packages/web/examples/SearchBox`
+- `next/packages/web/examples/SearchBoxWithPillSuggestions`
+- `feat/faq-suggestions/packages/web/examples/SearchBoxWithFAQSuggestions`
+- `next/packages/web/examples/ReactiveList`
+- `next/packages/web/examples/SingleList`
+
+**Docs inline vs CSB (optional follow-up):** `singlelist.md` and `reactivelist.md` inline `endpoint` snippets still use `/recipes-demo/_reactivesearch` on 9-4-0; embedded CSB examples on `next` use `good-books-ds`. Align inline snippets when verifying those pages.
+
+---
+
+## P1 — atlas-search + analytics (10)
+
+Docs pages: `/docs/reactivesearch/atlas-search/search-examples-with-react`, `search-examples-with-vue`, `/docs/analytics/popular-recent-suggestions`.
+
+> **Note:** 9 of 10 use `mongo-examples/*` (MongoDB Atlas). Only `QuerySuggestion` uses Render ES. Migrate `QuerySuggestion` now; defer mongo block unless Atlas connection strings are also being updated.
+
+### P1 checklist
+
+- [ ] `next/packages/maps/examples/mongo-examples/GeoDistanceDropdown` — MongoDB Atlas — defer
+- [ ] `next/packages/maps/examples/mongo-examples/GeoDistanceSlider` — MongoDB Atlas — defer
+- [ ] `next/packages/maps/examples/mongo-examples/ReactiveMap` — MongoDB Atlas — defer
+- [ ] `next/packages/vue/examples/mongo-examples/data-search` — MongoDB Atlas — defer
+- [ ] `next/packages/vue/examples/mongo-examples/multi-list` — MongoDB Atlas — defer
+- [ ] `next/packages/vue/examples/mongo-examples/range-input` — MongoDB Atlas — defer
+- [ ] `next/packages/web/examples/QuerySuggestion` — clone-airbeds
+- [ ] `next/packages/web/examples/mongo-examples/DataSearch` — MongoDB Atlas — defer
+- [ ] `next/packages/web/examples/mongo-examples/MultiList` — MongoDB Atlas — defer
+- [ ] `next/packages/web/examples/mongo-examples/RangeInput` — MongoDB Atlas — defer
+
+---
+
+## `recipes-demo` dependents
+
+`SingleList` is P0 ✅. **~61 checklist items** below (in branch sections) historically used `recipes-demo/_reactivesearch.v3`. Until the `recipes-demo` index finishes importing to Render ES, retarget to **`good-books-ds`** (field schema differs — verify facets still work). Items are marked `recipes-demo → good-books-ds (interim)` in the branch checklists.
+
+**React web:** `MultiList`, `MultiListAntd`, `MultiDataList`, `MultiDropdownList`, `SingleDataList`, `SingleDropdownList`, `TabDataList`, `TreeList`, `TreeListWithCustomSelectedFilters`, `TagCloud`, `ToggleButton`, `RangeInput`, `RangeSlider`, `SingleRange`, `MultiRange`, `DynamicRangeSlider`, `NumberBox`, `DatePicker`, `DateRange`, `RatingsFilter`, `SingleDropdownRange`, `MultiDropdownRange`, `ResultCard`, `ResultList`
+
+**Vue (`next` + `feat/just-for-csb-002`):** `multi-list`, `single-list`, `multi-dropdown-list`, `single-dropdown-list`, `tree-list`, `toggle-button`, `range-input`, `range-slider`, `single-range`, `multi-Range`, `dynamic-range-slider`, `reactive-component`, `reactive-component-with-custom-query`, `reactive-list`, `reactivelist-with-aggregation`, `reactivelist-without-aggregation`, `result-card`, `result-list`, `selected-filters-custom`
+
+**Dev branch:** `ReactiveComponent`, `SelectedFilters`
+
+---
+
+## Other — grouped by branch
+
+## Branch: `next` — `packages/web/examples`
+
+- [x] `next/packages/web/examples/AIAnswer` — good-books-ds
+- [x] `next/packages/web/examples/CategorySearch` — good-books-ds
+- [x] `next/packages/web/examples/DataSearch` — good-books-ds
+- [x] `next/packages/web/examples/DataSearchWithAggregation` — good-books-ds
+- [x] `next/packages/web/examples/DatePicker` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/DateRange` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/DynamicRangeSlider` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/ErrorBoundary` — good-books-ds
+- [x] `next/packages/web/examples/MultiDataList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/MultiDropdownList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/MultiDropdownRange` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/MultiIndexFacet` — good-books-ds + good-books
+- [x] `next/packages/web/examples/MultiIndexSearch` — good-books-ds + good-books
+- [x] `next/packages/web/examples/MultiList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/MultiListAntd` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/MultiRange` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/NumberBox` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/PathBasedRouting` — good-books-ds
+- [x] `next/packages/web/examples/Preferences` — good-books-ds
+- [x] `next/packages/web/examples/RangeInput` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/RangeSlider` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/RatingsFilter` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/ReactiveChart/Bar` — good-books-ds
+- [x] `next/packages/web/examples/ReactiveChart/Histogram` — good-books-ds
+- [x] `next/packages/web/examples/ReactiveChart/Line` — good-books-ds
+- [x] `next/packages/web/examples/ReactiveChart/Pie` — good-books-ds
+- [x] `next/packages/web/examples/ReactiveChart/Scatter` — good-books-ds
+- [x] `next/packages/web/examples/ReactiveChart/StackedBarChart` — good-books-ds
+- [x] `next/packages/web/examples/ReactiveListWithAggregation` — good-books-ds
+- [x] `next/packages/web/examples/ResultCard` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/ResultList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/RichSnippets` — good-books-ds
+- [x] `next/packages/web/examples/SavedSearch` — good-books-ds
+- [x] `next/packages/web/examples/SearchBoxWithFeaturedSuggestions` — good-books-ds
+- [x] `next/packages/web/examples/SingleDataList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/SingleDropdownList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/SingleDropdownRange` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/SingleRange` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/TabDataList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/TagCloud` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/ToggleButton` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/TreeList` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/TreeListWithCustomSelectedFilters` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/web/examples/ssr` — good-books-ds
+
+## Branch: `next` — `packages/vue/examples`
+
+- [x] `next/packages/vue/examples/ai-answer` — good-books-ds
+- [x] `next/packages/vue/examples/analytics-with-hook` — good-books-ds
+- [x] `next/packages/vue/examples/dynamic-range-slider` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/multi-Range` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/multi-dropdown-list` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/multi-list` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/preferences` — good-books-ds
+- [x] `next/packages/vue/examples/range-input` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/range-slider` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/reactive-component` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/reactive-component-with-custom-query` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/reactive-list` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/result-card` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/result-list` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/saved-search` — good-books-ds
+- [x] `next/packages/vue/examples/search-box` — good-books-ds
+- [x] `next/packages/vue/examples/selected-filters-custom` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/single-dropdown-list` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/single-list` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/single-range` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/toggle-button` — recipes-demo → good-books-ds (interim)
+- [x] `next/packages/vue/examples/tree-list` — recipes-demo → good-books-ds (interim)
+
+## Branch: `next` — `packages/maps/examples`
+
+- [x] `next/packages/maps/examples/GeoDistanceDropdown` — clone-airbeds
+- [x] `next/packages/maps/examples/GeoDistanceSlider` — clone-airbeds
+- [x] `next/packages/maps/examples/QuickStartStep1` — clone-airbeds
+- [x] `next/packages/maps/examples/QuickStartStep2` — clone-airbeds
+- [x] `next/packages/maps/examples/ReactiveMap` — clone-airbeds
+
+## Branch: `dev` (4)
+
+- [ ] `dev/packages/vue/examples/with-ssr` — good-books-ds
+- [ ] `dev/packages/web/examples/ReactiveComponent` — recipes-demo → good-books-ds (interim)
+- [ ] `dev/packages/web/examples/SelectedFilters` — recipes-demo → good-books-ds (interim)
+- [ ] `dev/packages/web/examples/ssr` — good-books-ds
+
+## Branch: `v3` (5) — legacy MyAwesomeSearch duplicate
+
+Legacy quickstart embeds on `/docs/reactivesearch/react/v3/overview/quickstart`. Prefer consolidating to `next` branch examples.
+
+- [ ] `v3/packages/web/examples/MyAwesomeSearchStep1` — good-books-ds (legacy `v3` duplicate)
+- [ ] `v3/packages/web/examples/MyAwesomeSearchStep2` — good-books-ds (legacy `v3` duplicate)
+- [ ] `v3/packages/web/examples/MyAwesomeSearchStep3` — good-books-ds (legacy `v3` duplicate)
+- [ ] `v3/packages/web/examples/MyAwesomeSearchStep4` — good-books-ds (legacy `v3` duplicate)
+- [ ] `v3/packages/web/examples/MyAwesomeSearchStep5` — good-books-ds (legacy `v3` duplicate)
+
+## Branch: `vue-maps` (4)
+
+Legacy Google Maps examples; require Google Maps API key in addition to backend migration.
+
+- [ ] `vue-maps/packages/vue/examples/reactive-google-map` — clone-airbeds (+ Google Maps API key)
+- [ ] `vue-maps/packages/vue/examples/reactive-google-map-aggregations` — clone-airbeds (+ Google Maps API key)
+- [ ] `vue-maps/packages/vue/examples/reactive-google-map-default-query` — clone-airbeds (+ Google Maps API key)
+- [ ] `vue-maps/packages/vue/examples/reactive-google-map-nuxt` — clone-airbeds (+ Google Maps API key)
+
+## Branch: `feat/just-for-csb-002` (23) — Vue v1 CodeSandbox branch
+
+Stale branch used by `/docs/reactivesearch/vue/v1/*` pages. Consider merging into `next` after migration.
+
+- [ ] `feat/just-for-csb-002/packages/vue/examples/analytics-with-hook` — good-books-ds
+- [ ] `feat/just-for-csb-002/packages/vue/examples/data-search` — good-books-ds
+- [ ] `feat/just-for-csb-002/packages/vue/examples/dynamic-range-slider` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/multi-Range` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/multi-dropdown-list` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/multi-list` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/preferences` — good-books-ds
+- [ ] `feat/just-for-csb-002/packages/vue/examples/range-input` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/range-slider` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/reactive-component` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/reactive-component-with-custom-query` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/reactive-list` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/reactivelist-with-aggregation` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/reactivelist-without-aggregation` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/result-card` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/result-list` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/saved-search` — good-books-ds
+- [ ] `feat/just-for-csb-002/packages/vue/examples/search-box` — good-books-ds
+- [ ] `feat/just-for-csb-002/packages/vue/examples/selected-filters-custom` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/single-dropdown-list` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/single-list` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/single-range` — recipes-demo → good-books-ds (interim)
+- [ ] `feat/just-for-csb-002/packages/vue/examples/toggle-button` — recipes-demo → good-books-ds (interim)
+
+## Branch: `feat/faq-suggestions` (non-P0)
+
+- [ ] `feat/faq-suggestions/packages/vue/examples/search-showcase/faq-suggestions` — good-books-ds
+
+## Branch: `feat/vue-showcase` (2)
+
+- [ ] `feat/vue-showcase/packages/vue/examples/search-showcase/featured-suggestions` — good-books-ds
+- [ ] `feat/vue-showcase/packages/vue/examples/search-showcase/searchbox-inline-ai-response` — good-books-ds
+
+---
+
+## `mongo-examples` — separate migration or skip
+
+These 9 CodeSandbox embeds connect to **MongoDB Atlas**, not the Render OpenSearch backend. Do **not** apply the Render ES replace cheatsheet. Options:
+
+1. **Skip** until a dedicated Mongo demo backend is provisioned
+2. **Separate ticket** to update Atlas connection strings / credentials
+3. **Retarget** docs to ES equivalents on `next` (non-mongo) examples where they exist
+
+| Path | Docs reference |
+|------|----------------|
+| `next/packages/maps/examples/mongo-examples/GeoDistanceDropdown` | `atlas-search/search-examples-with-react` |
+| `next/packages/maps/examples/mongo-examples/GeoDistanceSlider` | `atlas-search/search-examples-with-react` |
+| `next/packages/maps/examples/mongo-examples/ReactiveMap` | `atlas-search/search-examples-with-react` |
+| `next/packages/vue/examples/mongo-examples/data-search` | `atlas-search/search-examples-with-vue` |
+| `next/packages/vue/examples/mongo-examples/multi-list` | `atlas-search/search-examples-with-vue` |
+| `next/packages/vue/examples/mongo-examples/range-input` | `atlas-search/search-examples-with-vue` |
+| `next/packages/web/examples/mongo-examples/DataSearch` | `atlas-search/search-examples-with-react` |
+| `next/packages/web/examples/mongo-examples/MultiList` | `atlas-search/search-examples-with-react` |
+| `next/packages/web/examples/mongo-examples/RangeInput` | `atlas-search/search-examples-with-react` |
+
+---
+
+## Appendix — other CodeSandbox repos (not this checklist)
+
+These appear in Docs but live in **other** repos. Track separately.
+
+### `appbaseio/vue-quick-start` (6 embeds)
+
+`/docs/reactivesearch/vue/overview/QuickStart` — steps 1–5 + final. P0 Docs pages already use Render ES inline; CSB repo may still point at old backend.
+
+### `appbaseio/searchbox` (~30+ embeds)
+
+- `packages/react-searchbox/examples/*` — react-searchbox docs, atlas-search searchbox examples, analytics popular suggestions
+- `packages/vue-searchbox/examples/*` — vue-searchbox docs, atlas-search
+- `packages/searchbox/examples/*` — searchbox quickstart / API
+- `packages/searchbase/examples/with-facet` — searchbase QuickStart
+
+### `appbaseio/searchbase` (2 embeds)
+
+- `packages/searchbase/examples/with-react`
+- `packages/searchbase/examples/with-vanilla`
+
+---
+
+## Verification grep (Docs repo)
+
+Re-run after reactivesearch migration to confirm no stale hosts remain **in reactivesearch CSB URLs**:
+
+```bash
+rg 'codesandbox.io.*appbaseio/reactivesearch' content/ src/
+rg 'searchbase\.io|_reactivesearch\.v3' content/ src/   # broader stale-host scan
+```

--- a/utils/demo-migration/migrate-demo-indexes.py
+++ b/utils/demo-migration/migrate-demo-indexes.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Migrate demo Elasticsearch indices from legacy cluster to Aiven OpenSearch.
+
+Each entry: (source_physical_index, destination_index_name)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# (source physical index, destination alias/name used by demos)
+DEMO_INDICES = [
+    ("good-books_reindexed_5", "good-books"),
+    ("clone-airbeds_reindexed_22", "clone-airbeds"),
+    ("earthquakes_reindexed_1", "earthquakes"),
+    ("docs-demo_reindexed_3", "docs-demo"),
+    ("best-buy-dataset_reindexed_6", "best-buy-dataset"),
+    ("recipes-demo", "recipes-demo"),  # use --max-docs for ~10% sample
+]
+
+EXPORT_ROOT = Path(__file__).resolve().parent / "export"
+BULK_CHUNK_LINES = 1000
+
+
+def basic_auth_header(url: str) -> str:
+    creds = url.split("://", 1)[1].split("@", 1)[0]
+    return base64.b64encode(creds.encode()).decode()
+
+
+def base_url(url: str) -> str:
+    scheme, rest = url.split("://", 1)
+    host = rest.split("@", 1)[1]
+    return f"{scheme}://{host}"
+
+
+def _request_with_retry(fn, label: str, max_attempts: int = 8):
+    delay = 2.0
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn()
+        except (urllib.error.URLError, ConnectionResetError, TimeoutError, OSError) as e:
+            if attempt == max_attempts:
+                raise RuntimeError(f"{label} failed after {max_attempts} attempts: {e}") from e
+            print(f"    {label} retry {attempt}/{max_attempts} ({e}); waiting {delay:.0f}s…")
+            time.sleep(delay)
+            delay = min(delay * 2, 60.0)
+
+
+def http_json(method: str, url: str, path: str, body=None, auth_header: str = "", timeout: int = 120):
+    def do_request():
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url + path, data=data, method=method)
+        if auth_header:
+            req.add_header("Authorization", f"Basic {auth_header}")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        ctx = ssl.create_default_context()
+        try:
+            with urllib.request.urlopen(req, context=ctx, timeout=timeout) as resp:
+                raw = resp.read().decode()
+                if method == "HEAD":
+                    return resp.status, {}
+                return resp.status, json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            raw = e.read().decode()
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                payload = {"error": raw}
+            return e.code, payload
+
+    return _request_with_retry(do_request, f"{method} {path}")
+
+
+def http_bulk(url: str, ndjson: bytes, auth_header: str):
+    def do_request():
+        req = urllib.request.Request(url + "/_bulk?refresh=false", data=ndjson, method="POST")
+        req.add_header("Authorization", f"Basic {auth_header}")
+        req.add_header("Content-Type", "application/x-ndjson")
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(req, context=ctx, timeout=600) as resp:
+            return json.loads(resp.read().decode())
+
+    return _request_with_retry(do_request, "bulk")
+
+
+def export_index(
+    source_base: str, auth: str, src_index: str, dest_index: str, export_dir: Path, max_docs: int | None = None
+):
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    code, settings_wrap = http_json("GET", source_base, f"/{src_index}/_settings", auth_header=auth)
+    if code != 200:
+        raise RuntimeError(f"settings export failed ({code}): {settings_wrap}")
+
+    code, mapping_wrap = http_json("GET", source_base, f"/{src_index}/_mapping", auth_header=auth)
+    if code != 200:
+        raise RuntimeError(f"mapping export failed ({code}): {mapping_wrap}")
+
+    (export_dir / "settings.json").write_text(json.dumps(settings_wrap))
+    (export_dir / "mapping.json").write_text(json.dumps(mapping_wrap))
+
+    count = 0
+    bulk_path = export_dir / "data.bulk.ndjson"
+    with bulk_path.open("w") as f:
+        code, res = http_json(
+            "POST",
+            source_base,
+            f"/{src_index}/_search?scroll=10m",
+            {"size": 500, "query": {"match_all": {}}},
+            auth_header=auth,
+            timeout=300,
+        )
+        if code != 200:
+            raise RuntimeError(f"search failed ({code}): {res}")
+        scroll_id = res["_scroll_id"]
+        while True:
+            hits = res["hits"]["hits"]
+            if not hits:
+                break
+            for h in hits:
+                f.write(json.dumps({"index": {"_index": dest_index, "_id": h["_id"]}}) + "\n")
+                f.write(json.dumps(h["_source"]) + "\n")
+                count += 1
+                if max_docs and count >= max_docs:
+                    break
+            if max_docs and count >= max_docs:
+                break
+            if count % 10000 == 0:
+                print(f"    exported {count} docs…")
+            code, res = http_json(
+                "POST",
+                source_base,
+                "/_search/scroll",
+                {"scroll": "10m", "scroll_id": scroll_id},
+                auth_header=auth,
+                timeout=300,
+            )
+            if code != 200:
+                raise RuntimeError(f"scroll failed ({code}): {res}")
+            scroll_id = res.get("_scroll_id", scroll_id)
+        http_json("DELETE", source_base, "/_search/scroll", {"scroll_id": scroll_id}, auth_header=auth)
+
+    return count
+
+
+def build_create_payload(export_dir: Path, src_index: str) -> dict:
+    settings_wrap = json.loads((export_dir / "settings.json").read_text())
+    mapping_wrap = json.loads((export_dir / "mapping.json").read_text())
+    settings = settings_wrap[src_index]["settings"]
+    mapping = mapping_wrap[src_index]["mappings"]
+    index_settings = settings.get("index", {})
+    for key in (
+        "creation_date",
+        "uuid",
+        "version",
+        "provided_name",
+        "routing",
+        "store",
+        "blocks",
+        "resize",
+        "history",  # private on OpenSearch — cannot be set on create
+    ):
+        index_settings.pop(key, None)
+    # demo cluster: single shard, no replicas
+    index_settings["number_of_shards"] = "1"
+    index_settings["number_of_replicas"] = "0"
+    index_settings.pop("auto_expand_replicas", None)
+    return {"settings": {"index": index_settings}, "mappings": mapping}
+
+
+def import_index(dest_base: str, auth: str, src_index: str, dest_index: str, export_dir: Path, skip_existing: bool):
+    bulk_path = export_dir / "data.bulk.ndjson"
+    if not bulk_path.exists():
+        raise RuntimeError(f"missing {bulk_path}")
+
+    code, _ = http_json("HEAD", dest_base, f"/{dest_index}", auth_header=auth)
+    if code == 200 and skip_existing:
+        code, count = http_json("GET", dest_base, f"/{dest_index}/_count", auth_header=auth)
+        print(f"  skip {dest_index} (exists, count={count.get('count')})")
+        return count.get("count", 0)
+
+    payload = build_create_payload(export_dir, src_index)
+    if code == 404:
+        print(f"  creating {dest_index}…")
+        code, res = http_json("PUT", dest_base, f"/{dest_index}", payload, auth_header=auth, timeout=300)
+        if code not in (200, 201):
+            raise RuntimeError(f"create failed ({code}): {res}")
+    elif code == 200:
+        print(f"  reindexing into existing {dest_index}…")
+
+    loaded = 0
+    chunk_lines: list[str] = []
+
+    def flush_chunk():
+        nonlocal loaded, chunk_lines
+        if not chunk_lines:
+            return
+        chunk = "\n".join(chunk_lines) + "\n"
+        result = http_bulk(dest_base, chunk.encode(), auth)
+        if result.get("errors"):
+            err_items = [it for it in result.get("items", []) if "error" in it.get("index", {})][:3]
+            raise RuntimeError(f"bulk errors: {json.dumps(err_items, indent=2)}")
+        loaded += len(chunk_lines) // 2
+        if loaded % 10000 == 0:
+            print(f"    loaded {loaded} docs…")
+        chunk_lines = []
+
+    with bulk_path.open() as f:
+        for line in f:
+            chunk_lines.append(line.rstrip("\n"))
+            if len(chunk_lines) >= BULK_CHUNK_LINES:
+                flush_chunk()
+    flush_chunk()
+    print(f"    loaded {loaded} docs (final)")
+
+    http_json("POST", dest_base, f"/{dest_index}/_refresh", auth_header=auth)
+    code, count = http_json("GET", dest_base, f"/{dest_index}/_count", auth_header=auth)
+    return count.get("count", 0)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--export-only", action="store_true")
+    parser.add_argument("--import-only", action="store_true")
+    parser.add_argument("--index", action="append", help="destination index name(s) to migrate")
+    parser.add_argument("--force", action="store_true", help="re-import even if index exists")
+    parser.add_argument("--max-docs", type=int, default=None, help="limit export to N documents (for large indices)")
+    args = parser.parse_args()
+
+    source_url = os.environ.get("SOURCE_URL")
+    dest_url = os.environ.get("DEST_URL")
+    if not args.import_only and not source_url:
+        sys.exit("Set SOURCE_URL")
+    if not args.export_only and not dest_url:
+        sys.exit("Set DEST_URL")
+
+    selected = {d for _, d in DEMO_INDICES}
+    if args.index:
+        selected = set(args.index)
+
+    pairs = [(s, d) for s, d in DEMO_INDICES if d in selected]
+    if not pairs:
+        sys.exit(f"No matching indices. Available: {[d for _, d in DEMO_INDICES]}")
+
+    source_auth = basic_auth_header(source_url) if source_url else ""
+    dest_auth = basic_auth_header(dest_url) if dest_url else ""
+    source_base = base_url(source_url) if source_url else ""
+    dest_base = base_url(dest_url) if dest_url else ""
+
+    for src_index, dest_index in pairs:
+        export_dir = EXPORT_ROOT / dest_index
+        print(f"\n=== {src_index} → {dest_index} ===")
+        if not args.import_only:
+            print("  exporting…")
+            n = export_index(
+                source_base, source_auth, src_index, dest_index, export_dir, max_docs=args.max_docs
+            )
+            print(f"  exported {n} docs")
+        if not args.export_only:
+            print("  importing…")
+            n = import_index(dest_base, dest_auth, src_index, dest_index, export_dir, skip_existing=not args.force)
+            print(f"  done: {dest_index} count={n}")
+
+    print("\nAll requested migrations finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/demo-migration/migrate-good-books-ds.py
+++ b/utils/demo-migration/migrate-good-books-ds.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Migrate good-books-ds from legacy demo ES to Aiven OpenSearch.
+
+Source physical index: good-books-ds_reindexed_9 (alias: good-books-ds)
+Destination index:      good-books-ds
+
+Usage:
+  export SOURCE_URL='https://USER:PASS@source-host'
+  export DEST_URL='https://USER:PASS@dest-host:PORT'
+  python3 migrate-good-books-ds.py
+
+Or pass --import-only to load from ./export/ (after a prior --export-only run).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+SRC_INDEX = "good-books-ds_reindexed_9"
+DEST_INDEX = "good-books-ds"
+EXPORT_DIR = Path(__file__).resolve().parent / "export"
+BULK_CHUNK_LINES = 1000  # 500 docs (2 lines each)
+
+
+def basic_auth_header(url: str) -> str:
+    # urllib doesn't embed auth from URL for Request; extract if needed
+    if "@" not in url:
+        return ""
+    creds = url.split("://", 1)[1].split("@", 1)[0]
+    return base64.b64encode(creds.encode()).decode()
+
+
+def base_url(url: str) -> str:
+    if "@" in url:
+        scheme, rest = url.split("://", 1)
+        host = rest.split("@", 1)[1]
+        return f"{scheme}://{host}"
+    return url.rstrip("/")
+
+
+def http_json(method: str, url: str, path: str, body=None, auth_header: str = ""):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url + path, data=data, method=method)
+    if auth_header:
+        req.add_header("Authorization", f"Basic {auth_header}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, context=ctx, timeout=120) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            payload = {"error": raw}
+        return e.code, payload
+
+
+def http_bulk(url: str, ndjson: bytes, auth_header: str):
+    req = urllib.request.Request(url + "/_bulk?refresh=false", data=ndjson, method="POST")
+    req.add_header("Authorization", f"Basic {auth_header}")
+    req.add_header("Content-Type", "application/x-ndjson")
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, context=ctx, timeout=300) as resp:
+        return json.loads(resp.read().decode())
+
+
+def export_from_source(source_url: str, auth_header: str):
+    EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+    base = base_url(source_url)
+
+    print("Exporting settings…")
+    code, settings_wrap = http_json("GET", base, f"/{SRC_INDEX}/_settings?pretty=false", auth_header=auth_header)
+    if code != 200:
+        sys.exit(f"settings export failed ({code}): {settings_wrap}")
+
+    print("Exporting mapping…")
+    code, mapping_wrap = http_json("GET", base, f"/{SRC_INDEX}/_mapping?pretty=false", auth_header=auth_header)
+    if code != 200:
+        sys.exit(f"mapping export failed ({code}): {mapping_wrap}")
+
+    (EXPORT_DIR / "settings.json").write_text(json.dumps(settings_wrap))
+    (EXPORT_DIR / "mapping.json").write_text(json.dumps(mapping_wrap))
+
+    print("Exporting documents via scroll…")
+    count = 0
+    bulk_path = EXPORT_DIR / "data.bulk.ndjson"
+    with bulk_path.open("w") as f:
+        code, res = http_json(
+            "POST",
+            base,
+            f"/{SRC_INDEX}/_search?scroll=5m",
+            {"size": 500, "query": {"match_all": {}}},
+            auth_header=auth_header,
+        )
+        if code != 200:
+            sys.exit(f"search failed ({code}): {res}")
+        scroll_id = res["_scroll_id"]
+        while True:
+            hits = res["hits"]["hits"]
+            if not hits:
+                break
+            for h in hits:
+                f.write(json.dumps({"index": {"_index": DEST_INDEX, "_id": h["_id"]}}) + "\n")
+                f.write(json.dumps(h["_source"]) + "\n")
+                count += 1
+            code, res = http_json(
+                "POST", base, "/_search/scroll", {"scroll": "5m", "scroll_id": scroll_id}, auth_header=auth_header
+            )
+            if code != 200:
+                sys.exit(f"scroll failed ({code}): {res}")
+            scroll_id = res.get("_scroll_id", scroll_id)
+        http_json("DELETE", base, "/_search/scroll", {"scroll_id": scroll_id}, auth_header=auth_header)
+
+    print(f"Exported {count} documents to {bulk_path}")
+
+
+def build_create_payload() -> dict:
+    settings_wrap = json.loads((EXPORT_DIR / "settings.json").read_text())
+    mapping_wrap = json.loads((EXPORT_DIR / "mapping.json").read_text())
+    settings = settings_wrap[SRC_INDEX]["settings"]
+    mapping = mapping_wrap[SRC_INDEX]["mappings"]
+    index_settings = settings.get("index", {})
+    for key in ("creation_date", "uuid", "version", "provided_name", "routing", "store"):
+        index_settings.pop(key, None)
+    return {"settings": {"index": index_settings}, "mappings": mapping}
+
+
+def import_to_dest(dest_url: str, auth_header: str):
+    base = base_url(dest_url)
+    print("Checking destination cluster…")
+    code, health = http_json("GET", base, "/_cluster/health", auth_header=auth_header)
+    if code != 200:
+        sys.exit(f"Destination auth/health failed ({code}): {health}")
+
+    payload = build_create_payload()
+    (EXPORT_DIR / "create-index.json").write_text(json.dumps(payload, indent=2))
+
+    code, exists = http_json("HEAD", base, f"/{DEST_INDEX}", auth_header=auth_header)
+    if code == 404:
+        print(f"Creating index {DEST_INDEX}…")
+        code, res = http_json("PUT", base, f"/{DEST_INDEX}", payload, auth_header=auth_header)
+        if code not in (200, 201):
+            sys.exit(f"Create index failed ({code}): {res}")
+        print("Index created.")
+    else:
+        print(f"Index {DEST_INDEX} already exists (status {code}); skipping create.")
+
+    bulk_path = EXPORT_DIR / "data.bulk.ndjson"
+    if not bulk_path.exists():
+        sys.exit(f"Missing {bulk_path}; run export first.")
+
+    print("Bulk loading documents…")
+    lines = bulk_path.read_text().splitlines()
+    loaded = 0
+    for i in range(0, len(lines), BULK_CHUNK_LINES):
+        chunk = "\n".join(lines[i : i + BULK_CHUNK_LINES]) + "\n"
+        result = http_bulk(base, chunk.encode(), auth_header)
+        if result.get("errors"):
+            sys.exit(f"Bulk errors: {json.dumps(result, indent=2)[:2000]}")
+        loaded += len(lines[i : i + BULK_CHUNK_LINES]) // 2
+        print(f"  …{loaded} docs")
+
+    http_json("POST", base, f"/{DEST_INDEX}/_refresh", auth_header=auth_header)
+    code, count = http_json("GET", base, f"/{DEST_INDEX}/_count", auth_header=auth_header)
+    print(f"Done. _count on {DEST_INDEX}: {count}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--export-only", action="store_true")
+    parser.add_argument("--import-only", action="store_true")
+    args = parser.parse_args()
+
+    source_url = os.environ.get("SOURCE_URL")
+    dest_url = os.environ.get("DEST_URL")
+    if not args.import_only and not source_url:
+        sys.exit("Set SOURCE_URL for export (or use --import-only).")
+    if not args.export_only and not dest_url:
+        sys.exit("Set DEST_URL for import (or use --export-only).")
+
+    if not args.import_only:
+        export_from_source(source_url, basic_auth_header(source_url))
+    if not args.export_only:
+        import_to_dest(dest_url, basic_auth_header(dest_url))
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/demo-migration/render/Dockerfile
+++ b/utils/demo-migration/render/Dockerfile
@@ -1,0 +1,5 @@
+# Minimal ReactiveSearch API for Render (no bundled Elasticsearch).
+# Connect to external Aiven / Elastic Cloud via ES_CLUSTER_URL.
+FROM appbaseio/reactivesearch-api:9.3.0
+
+EXPOSE 8000

--- a/utils/demo-migration/render/render.yaml
+++ b/utils/demo-migration/render/render.yaml
@@ -1,0 +1,34 @@
+# Render Blueprint — ReactiveSearch API gateway for demo backends
+#
+# Deploy:
+#   1. Fork/push this folder to a repo Render can access
+#   2. In Render: New > Blueprint > connect repo (root: utils/demo-migration/render)
+#   3. Set ES_CLUSTER_URL secret in dashboard (Aiven OpenSearch URI with creds)
+#
+# Notes:
+#   - Persistent disk keeps RS users / ACL config across restarts (Starter+ plan)
+#   - Set service Port to 8000 in Render dashboard if health checks fail
+#   - Free tier spins down on idle — not ideal for CodeSandbox embeds
+
+services:
+  - type: web
+    name: rs-api-demo
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    plan: starter
+    region: oregon
+    healthCheckPath: /
+    numInstances: 1
+    disk:
+      name: rs-data
+      mountPath: /reactivesearch-data
+      sizeGB: 1
+    envVars:
+      - key: ES_CLUSTER_URL
+        sync: false
+      - key: USERNAME
+        value: rs-admin-user
+      - key: PASSWORD
+        generateValue: true
+      - key: PORT
+        value: "8000"

--- a/utils/demo-migration/run-migration.sh
+++ b/utils/demo-migration/run-migration.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Run a single demo index migration with full logging.
+# Usage: ./run-migration.sh <index-name>
+#   index-name: best-buy-dataset | recipes-demo
+
+set -euo pipefail
+export PYTHONUNBUFFERED=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_DIR="${SCRIPT_DIR}/logs"
+MIGRATE_PY="${SCRIPT_DIR}/migrate-demo-indexes.py"
+
+INDEX_NAME="${1:-}"
+if [[ -z "${INDEX_NAME}" ]]; then
+  echo "Usage: $0 <index-name>" >&2
+  echo "  index-name: best-buy-dataset | recipes-demo" >&2
+  exit 1
+fi
+
+case "${INDEX_NAME}" in
+  best-buy-dataset|recipes-demo) ;;
+  *)
+    echo "Unknown index: ${INDEX_NAME}" >&2
+    echo "  Supported: best-buy-dataset, recipes-demo" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${IMPORT_ONLY:-}" != "1" && -z "${SOURCE_URL:-}" ]]; then
+  echo "SOURCE_URL is not set" >&2
+  exit 1
+fi
+if [[ -z "${DEST_URL:-}" ]]; then
+  echo "DEST_URL is not set" >&2
+  exit 1
+fi
+
+mkdir -p "${LOG_DIR}"
+TIMESTAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
+LOG_FILE="${LOG_DIR}/${INDEX_NAME}-${TIMESTAMP}.log"
+
+# Redact credentials from URLs for logging
+redact_url() {
+  local url="$1"
+  echo "${url}" | sed -E 's|://[^@]+@|://***:***@|'
+}
+
+SOURCE_SAFE=""
+if [[ -n "${SOURCE_URL:-}" ]]; then
+  SOURCE_SAFE="$(redact_url "${SOURCE_URL}")"
+fi
+DEST_SAFE="$(redact_url "${DEST_URL}")"
+
+MIGRATE_ARGS=(--index "${INDEX_NAME}" --force)
+if [[ "${IMPORT_ONLY:-}" == "1" ]]; then
+  MIGRATE_ARGS+=(--import-only)
+else
+  if [[ "${INDEX_NAME}" == "recipes-demo" ]]; then
+    MIGRATE_ARGS+=(--max-docs 222286)
+  fi
+fi
+
+EXIT_CODE=0
+FINAL_COUNT="unknown"
+
+log() {
+  echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $*" | tee -a "${LOG_FILE}"
+}
+
+on_error() {
+  local line="$1"
+  log "ERROR: command failed at line ${line} (exit ${EXIT_CODE:-1})"
+  exit "${EXIT_CODE:-1}"
+}
+
+trap 'EXIT_CODE=$?; on_error ${LINENO}' ERR
+
+log "=== Migration start: ${INDEX_NAME}${IMPORT_ONLY:+ (import-only)} ==="
+log "Start time (UTC): $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+if [[ -n "${SOURCE_URL:-}" ]]; then
+  log "SOURCE_URL: ${SOURCE_SAFE}"
+fi
+log "DEST_URL: ${DEST_SAFE}"
+log "Command: python3 ${MIGRATE_PY} ${MIGRATE_ARGS[*]}"
+log ""
+
+# Run migration; tee stdout/stderr to log
+set +e
+python3 "${MIGRATE_PY}" "${MIGRATE_ARGS[@]}" 2>&1 | tee -a "${LOG_FILE}"
+EXIT_CODE="${PIPESTATUS[0]}"
+set -e
+
+log ""
+log "Migration script exit code: ${EXIT_CODE}"
+
+if [[ "${EXIT_CODE}" -eq 0 ]]; then
+  # Query final _count on destination
+  DEST_BASE="$(python3 -c "
+import os, sys
+url = os.environ['DEST_URL']
+scheme, rest = url.split('://', 1)
+host = rest.split('@', 1)[1]
+print(f'{scheme}://{host}')
+")"
+  DEST_AUTH="$(python3 -c "
+import os, base64
+creds = os.environ['DEST_URL'].split('://', 1)[1].split('@', 1)[0]
+print(base64.b64encode(creds.encode()).decode())
+")"
+
+  COUNT_RESPONSE="$(python3 -c "
+import json, os, ssl, urllib.request
+dest_base = '''${DEST_BASE}'''
+auth = '''${DEST_AUTH}'''
+index = '''${INDEX_NAME}'''
+req = urllib.request.Request(f'{dest_base}/{index}/_count')
+req.add_header('Authorization', f'Basic {auth}')
+ctx = ssl.create_default_context()
+with urllib.request.urlopen(req, context=ctx, timeout=60) as resp:
+    print(json.loads(resp.read().decode()).get('count', 'unknown'))
+" 2>/dev/null || echo "query_failed")"
+  FINAL_COUNT="${COUNT_RESPONSE}"
+  log "Final _count on Aiven: ${FINAL_COUNT}"
+else
+  log "Migration failed — see output above"
+fi
+
+log "End time (UTC): $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+log "Log file: ${LOG_FILE}"
+log "=== Migration end: ${INDEX_NAME} (exit ${EXIT_CODE}) ==="
+
+exit "${EXIT_CODE}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18085,9 +18085,9 @@ scroll-into-view-if-needed@^2.2.25:
   dependencies:
     compute-scroll-into-view "^1.0.20"
 
-"searchbox-showcase@https://github.com/awesome-reactivesearch/searchbox-showcase.git#ac58bba":
+"searchbox-showcase@https://github.com/awesome-reactivesearch/searchbox-showcase.git#fd402658":
   version "0.1.0"
-  resolved "https://github.com/awesome-reactivesearch/searchbox-showcase.git#ac58bba963d57cb7bdffeb0597d8914da90c6133"
+  resolved "https://github.com/awesome-reactivesearch/searchbox-showcase.git#fd4026582c48844ce383423d72f5933ba694bc0a"
   dependencies:
     bootstrap "^5.2.3"
     react-bootstrap "^2.7.2"


### PR DESCRIPTION
## Summary
- Retarget P0 docs demos (React/Vue/SearchBase quickstarts, JS API quickstart, SearchBox/ReactiveList/SingleList examples, React/Vue showcase pages) from legacy Searchbase hosts to `https://reactivesearch-api-9-3-0.onrender.com` with read-only demo credentials for `good-books-ds` (and interim `recipes-demo` endpoint where noted).
- Add `utils/demo-migration/` tooling: index export/import scripts, Render deployment config, run wrapper, and `MIGRATION-READINESS.md` tracking migration status and follow-up work.

## Test plan
- [ ] Run `yarn build` locally or rely on CI (pre-commit full build was skipped locally due to Gatsby hang after schema build).
- [ ] Open React overview quickstart and confirm live search against `good-books-ds` works.
- [ ] Open Vue overview QuickStart and confirm demo loads.
- [ ] Open SearchBase QuickStart and verify example requests succeed.
- [ ] Open React showcase (`clone-airbeds`) and confirm map/list demo.
- [ ] Spot-check SearchBox, ReactiveList, and SingleList doc examples.
- [ ] Open JS API quickstart and verify sample Appbase calls match the new index/host.
- [ ] Confirm `recipes-demo`-dependent SingleList facet demo behavior (may be partial until index import completes).


Made with [Cursor](https://cursor.com)